### PR TITLE
chore: release v1.6.5 — float dtype consistency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ name = "bbob-jax"
 readme = "README.md"
 requires-python = ">=3.12"
 urls = {repository = "https://github.com/bessagroup/bbob-jax"}
-version = "1.6.4"
+version = "1.6.5"
 
 [project.optional-dependencies]
 dev = [

--- a/src/bbob_jax/_src/bbob.py
+++ b/src/bbob_jax/_src/bbob.py
@@ -1088,8 +1088,8 @@ def _precompute_gallagher(
     key = jr.fold_in(key, Q[0, 0])
     key1, key2 = jr.split(key)
 
-    i = jnp.arange(1, num_peaks + 1, dtype=jnp.float_)
-    j = jnp.arange(0, num_peaks - 1, dtype=jnp.float_)
+    i = jnp.arange(1, num_peaks + 1, dtype=float)
+    j = jnp.arange(0, num_peaks - 1, dtype=float)
 
     w = 1.1 + 8.0 * ((i - 2) / w_divisor)
     w = w.at[0].set(10.0)
@@ -1106,7 +1106,7 @@ def _precompute_gallagher(
     # Compute diagonal vectors instead of full (ndim x ndim) matrices.
     # lambda_func(ndim, alpha_i) = diag(alpha_i^(idx / (2*(ndim-1))))
     # Then divided by alpha_i^0.25.
-    idx = jnp.arange(ndim, dtype=jnp.float_)
+    idx = jnp.arange(ndim, dtype=float)
     # alpha: (num_peaks,), idx: (ndim,) -> c_diags: (num_peaks, ndim)
     c_diags = jnp.power(
         alpha[:, None], idx[None, :] / (2 * (ndim - 1))
@@ -1296,7 +1296,7 @@ def katsuura(
         _mat = Q @ lambda_func(ndim, alpha=100.0) @ R
     z = _mat @ (x - x_opt)
 
-    J = 2.0 ** jnp.arange(1, 33, dtype=jnp.float_)  # (32,)
+    J = 2.0 ** jnp.arange(1, 33, dtype=float)  # (32,)
     # jsum term: shape (32, dim)
     z_expanded = z[None, :]  # (1, dim)
     J_expanded = J[:, None]  # (32, 1)

--- a/src/bbob_jax/_src/cec2005.py
+++ b/src/bbob_jax/_src/cec2005.py
@@ -141,7 +141,7 @@ def f3(
     """
     ndim = x.shape[-1]
     z = R @ (x - x_opt)
-    exponents = jnp.arange(ndim, dtype=jnp.float_) / jnp.maximum(ndim - 1, 1)
+    exponents = jnp.arange(ndim, dtype=float) / jnp.maximum(ndim - 1, 1)
     coeffs = 10.0 ** (6.0 * exponents)
     return jnp.sum(coeffs * z**2) + f_opt
 
@@ -578,7 +578,7 @@ def _rastrigin_base(z: jax.Array) -> jax.Array:
 def _elliptic_base(z: jax.Array) -> jax.Array:
     """High conditioned elliptic for composition use."""
     ndim = z.shape[-1]
-    exponents = jnp.arange(ndim, dtype=jnp.float_) / jnp.maximum(ndim - 1, 1)
+    exponents = jnp.arange(ndim, dtype=float) / jnp.maximum(ndim - 1, 1)
     coeffs = 10.0 ** (6.0 * exponents)
     return jnp.sum(coeffs * z**2)
 

--- a/src/bbob_jax/_src/registry.py
+++ b/src/bbob_jax/_src/registry.py
@@ -11,7 +11,7 @@ produce a callable benchmark function.
 
 # Standard
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, cast
 
 # Third-Party
@@ -129,7 +129,7 @@ def _conditioned_linear_transform(
     u = jr.uniform(key_u, shape=(dim,), minval=0.0, maxval=1.0)
     span = jnp.maximum(jnp.max(u) - jnp.min(u), 1e-12)
     exponents = (u - jnp.min(u)) / span
-    n = jnp.diag(jnp.asarray(condition_number, dtype=jnp.float_) ** exponents)
+    n = jnp.diag(jnp.asarray(condition_number, dtype=float) ** exponents)
     return p @ n @ q
 
 
@@ -172,10 +172,10 @@ def _sample_nonsingular_integer_matrix(
     attempt_keys = jr.split(key, 32)
     fallback = jr.randint(
         attempt_keys[0], (ndim, ndim), minval, maxval + 1
-    ).astype(jnp.float_)
+    ).astype(float)
     for attempt_key in attempt_keys:
         mat = jr.randint(attempt_key, (ndim, ndim), minval, maxval + 1).astype(
-            jnp.float_
+            float
         )
         if not jnp.isclose(jnp.linalg.det(mat), 0.0):
             return mat
@@ -295,7 +295,7 @@ def _make_linear_slope(fn: Callable, ndim: int, key: PRNGKeyArray) -> BBOBFn:
     rng = jr.key(0)
     rng = jr.fold_in(rng, kw["Q"][0, 0])
     ls_x_opt = 5 * bernoulli_vector(ndim, rng)
-    i = jnp.arange(1, ndim + 1, dtype=jnp.float_)
+    i = jnp.arange(1, ndim + 1, dtype=float)
     ls_s = jnp.sign(ls_x_opt) * jnp.power(10.0, (i - 1) / (ndim - 1))
     return Partial(fn, **kw, _ls_x_opt=ls_x_opt, _ls_s=ls_s), f_opt_val
 
@@ -309,7 +309,7 @@ def _make_linear_slope_deterministic(
     rng = jr.key(0)
     rng = jr.fold_in(rng, kw["Q"][0, 0])
     ls_x_opt = 5 * bernoulli_vector(ndim, rng)
-    i = jnp.arange(1, ndim + 1, dtype=jnp.float_)
+    i = jnp.arange(1, ndim + 1, dtype=float)
     ls_s = jnp.sign(ls_x_opt) * jnp.power(10.0, (i - 1) / (ndim - 1))
     return Partial(fn, **kw, _ls_x_opt=ls_x_opt, _ls_s=ls_s), f_opt_val
 
@@ -757,7 +757,7 @@ def make_randomized_cec2005_conditioned(
             ndim, r_key, float(jnp.asarray(condition_numbers))
         )
     else:
-        conds = jnp.asarray(condition_numbers, dtype=jnp.float_)
+        conds = jnp.asarray(condition_numbers, dtype=float)
         r_keys = jr.split(r_key, num_components)
         r = _conditioned_transform_stack(ndim, r_keys, conds)
     return Partial(fn, x_opt=x_opt, f_opt=f_opt_val, R=r, Q=q), f_opt_val
@@ -861,10 +861,8 @@ def _make_randomized_cec2005_f12(
     keys = jr.split(key, total_keys)
     x_opt = xopt(key=keys[-2], ndim=ndim, minval=-math.pi, maxval=math.pi)
     # A and B matrices: integer-valued in [-100, 100]
-    R = jr.randint(keys[0], (ndim, ndim), -100, 101).astype(jnp.float_)
-    Q = jr.randint(keys[num_components], (ndim, ndim), -100, 101).astype(
-        jnp.float_
-    )
+    R = jr.randint(keys[0], (ndim, ndim), -100, 101).astype(float)
+    Q = jr.randint(keys[num_components], (ndim, ndim), -100, 101).astype(float)
     f_opt_val = fopt(keys[-1])
     return Partial(fn, x_opt=x_opt, f_opt=f_opt_val, R=R, Q=Q), f_opt_val
 
@@ -900,7 +898,7 @@ def _make_randomized_cec2005_conditioned_single(
         num_components=1,
         minval=minval,
         maxval=maxval,
-        condition_numbers=jnp.array(condition_number, dtype=jnp.float_),
+        condition_numbers=jnp.array(condition_number, dtype=float),
     )
 
 
@@ -911,7 +909,7 @@ def _make_randomized_cec2005_f18_family(
     num_components: int = 10,
 ) -> BBOBFn:
     """Factory for F18/F19/F20 with paper condition numbers and o10=0."""
-    conds = jnp.array([2, 3, 2, 3, 2, 3, 20, 30, 200, 300], dtype=jnp.float_)
+    conds = jnp.array([2, 3, 2, 3, 2, 3, 20, 30, 200, 300], dtype=float)
     partial_fn, f_opt_val = make_randomized_cec2005_conditioned(
         fn,
         ndim,
@@ -954,89 +952,109 @@ def _make_randomized_cec2005_f20(
 
 _NC = 10  # num_components for all composition functions (F15-F25)
 
-# Lambda arrays shared by composition function groups
-_COMP1_LAMBDA = jnp.array(
-    [1, 1, 10, 10, 5 / 60, 5 / 60, 5 / 32, 5 / 32, 5 / 100, 5 / 100]
+# Lambda values shared by composition function groups. Stored as plain
+# Python tuples (not jnp.array) so that import order does not bake in a
+# dtype before the user has had a chance to call
+# ``jax.config.update("jax_enable_x64", True)``. The factories convert
+# them to jax.Array at call time via ``jnp.asarray(..., dtype=float)``.
+_COMP1_LAMBDA: tuple[float, ...] = (
+    1,
+    1,
+    10,
+    10,
+    5 / 60,
+    5 / 60,
+    5 / 32,
+    5 / 32,
+    5 / 100,
+    5 / 100,
 )
-_COMP2_LAMBDA_F18 = jnp.array(
-    [
-        2 * 5 / 32,
-        5 / 32,
-        2 * 1,
-        1,
-        2 * 5 / 100,
-        5 / 100,
-        2 * 10,
-        10,
-        2 * 5 / 60,
-        5 / 60,
-    ]
+_COMP2_LAMBDA_F18: tuple[float, ...] = (
+    2 * 5 / 32,
+    5 / 32,
+    2 * 1,
+    1,
+    2 * 5 / 100,
+    5 / 100,
+    2 * 10,
+    10,
+    2 * 5 / 60,
+    5 / 60,
 )
-_COMP2_LAMBDA_F19 = jnp.array(
-    [
-        0.1 * 5 / 32,
-        5 / 32,
-        2 * 1,
-        1,
-        2 * 5 / 100,
-        5 / 100,
-        2 * 10,
-        10,
-        2 * 5 / 60,
-        5 / 60,
-    ]
+_COMP2_LAMBDA_F19: tuple[float, ...] = (
+    0.1 * 5 / 32,
+    5 / 32,
+    2 * 1,
+    1,
+    2 * 5 / 100,
+    5 / 100,
+    2 * 10,
+    10,
+    2 * 5 / 60,
+    5 / 60,
 )
-_COMP3_LAMBDA = jnp.array(
-    [
-        5 * 5 / 100,
-        5 / 100,
-        5 * 1,
-        1,
-        5 * 1,
-        1,
-        5 * 10,
-        10,
-        5 * 5 / 200,
-        5 / 200,
-    ]
+_COMP3_LAMBDA: tuple[float, ...] = (
+    5 * 5 / 100,
+    5 / 100,
+    5 * 1,
+    1,
+    5 * 1,
+    1,
+    5 * 10,
+    10,
+    5 * 5 / 200,
+    5 / 200,
 )
 
 
 def _add_f_max(
     base_factory: Callable,
     comp_fns_builder: Callable,
-    comp_lambda: jax.Array,
+    comp_lambda: jax.Array | Sequence[float],
     fn: Callable,
     ndim: int,
     key: PRNGKeyArray,
     **factory_kwargs: Any,
 ) -> BBOBFn:
-    """Wrap any CEC2005 factory to add precomputed _f_max."""
+    """Wrap any CEC2005 factory to add precomputed _f_max.
+
+    ``comp_lambda`` may be a ``jax.Array`` or any sequence of floats;
+    it is converted to ``jax.Array`` at call time so registry entries
+    can store dtype-free Python tuples (see module-level
+    ``_COMP*_LAMBDA``).
+    """
     partial_fn, f_opt_val = base_factory(fn, ndim, key, **factory_kwargs)
     kw = _partial_keywords(partial_fn)
     M = kw["R"]
     # F15 uses identity stacks, but M is already set correctly by the factory
     fns = comp_fns_builder()
-    f_max = compute_composition_f_max(fns, comp_lambda, M, ndim)
+    lambda_arr = jnp.asarray(comp_lambda, dtype=float)
+    f_max = compute_composition_f_max(fns, lambda_arr, M, ndim)
     return Partial(fn, **kw, _f_max=f_max), f_opt_val
 
 
 def _add_f_max_deterministic(
     comp_fns_builder: Callable,
-    comp_lambda: jax.Array,
+    comp_lambda: jax.Array | Sequence[float],
     fn: Callable,
     ndim: int,
     key: PRNGKeyArray | None = None,
     num_components: int = _NC,
 ) -> BBOBFn:
-    """Deterministic factory with precomputed _f_max."""
+    """Deterministic factory with precomputed _f_max.
+
+    ``comp_lambda`` may be a ``jax.Array`` or any sequence of floats;
+    it is converted to ``jax.Array`` at call time so registry entries
+    can store dtype-free Python tuples.
+    """
     partial_fn, f_opt_val = make_deterministic_cec2005(
         fn, ndim, key, num_components
     )
     kw = _partial_keywords(partial_fn)
     M = kw["R"]
     fns = comp_fns_builder()
-    f_max = compute_composition_f_max(fns, comp_lambda, M, ndim)
+    lambda_arr = jnp.asarray(comp_lambda, dtype=float)
+    f_max = compute_composition_f_max(fns, lambda_arr, M, ndim)
     return Partial(fn, **kw, _f_max=f_max), f_opt_val
 
 
@@ -1134,7 +1152,7 @@ cec2005_registry: dict[str, Callable] = {
         num_components=_NC,
         minval=-5.0,
         maxval=5.0,
-        condition_numbers=jnp.full((_NC,), 2.0, dtype=jnp.float_),
+        condition_numbers=(2.0,) * _NC,
     ),
     "f17": Partial(
         _add_f_max,
@@ -1179,7 +1197,7 @@ cec2005_registry: dict[str, Callable] = {
         num_components=_NC,
         minval=-5.0,
         maxval=5.0,
-        condition_numbers=jnp.ones((_NC,), dtype=jnp.float_),
+        condition_numbers=(1.0,) * _NC,
     ),
     "f22": Partial(
         _add_f_max,
@@ -1190,9 +1208,17 @@ cec2005_registry: dict[str, Callable] = {
         num_components=_NC,
         minval=-5.0,
         maxval=5.0,
-        condition_numbers=jnp.array(
-            [10, 20, 50, 100, 200, 1000, 2000, 3000, 4000, 5000],
-            dtype=jnp.float_,
+        condition_numbers=(
+            10.0,
+            20.0,
+            50.0,
+            100.0,
+            200.0,
+            1000.0,
+            2000.0,
+            3000.0,
+            4000.0,
+            5000.0,
         ),
     ),
     "f23": Partial(
@@ -1204,7 +1230,7 @@ cec2005_registry: dict[str, Callable] = {
         num_components=_NC,
         minval=-5.0,
         maxval=5.0,
-        condition_numbers=jnp.ones((_NC,), dtype=jnp.float_),
+        condition_numbers=(1.0,) * _NC,
     ),
     "f24": Partial(
         make_randomized_cec2005_conditioned,
@@ -1212,8 +1238,17 @@ cec2005_registry: dict[str, Callable] = {
         num_components=_NC,
         minval=-5.0,
         maxval=5.0,
-        condition_numbers=jnp.array(
-            [100, 50, 30, 10, 5, 5, 4, 3, 2, 2], dtype=jnp.float_
+        condition_numbers=(
+            100.0,
+            50.0,
+            30.0,
+            10.0,
+            5.0,
+            5.0,
+            4.0,
+            3.0,
+            2.0,
+            2.0,
         ),
     ),
     "f25": Partial(
@@ -1222,8 +1257,17 @@ cec2005_registry: dict[str, Callable] = {
         num_components=_NC,
         minval=-5.0,
         maxval=5.0,
-        condition_numbers=jnp.array(
-            [100, 50, 30, 10, 5, 5, 4, 3, 2, 2], dtype=jnp.float_
+        condition_numbers=(
+            100.0,
+            50.0,
+            30.0,
+            10.0,
+            5.0,
+            5.0,
+            4.0,
+            3.0,
+            2.0,
+            2.0,
         ),
     ),
 }

--- a/src/bbob_jax/_src/utils.py
+++ b/src/bbob_jax/_src/utils.py
@@ -96,7 +96,7 @@ def tasy_func(x: jax.Array, beta: float = 0.5) -> jax.Array:
 
 def lambda_func(size: int, alpha: float | jax.Array = 10.0) -> jax.Array:
     """Diagonal conditioning matrix (Lambda) from the BBOB suite."""
-    idx = jnp.arange(size, dtype=jnp.float_)
+    idx = jnp.arange(size, dtype=float)
     diagonal = alpha ** (idx / (2 * (size - 1)))
     return jnp.diag(diagonal)
 
@@ -156,7 +156,7 @@ def bernoulli_vector(dim: int, key: jax.Array) -> jax.Array:
     jax.Array
         Vector of shape ``(dim,)`` with entries in {-1, 1}.
     """
-    return jr.bernoulli(key, p=0.5, shape=(dim,)).astype(jnp.float_) * 2 - 1
+    return jr.bernoulli(key, p=0.5, shape=(dim,)).astype(float) * 2 - 1
 
 
 def _create_mesh(
@@ -277,7 +277,7 @@ def cec2005_weierstrass(x: jax.Array) -> jax.Array:
         Scalar function value.
     """
     a, b = 0.5, 3.0
-    k = jnp.arange(0, 21, dtype=jnp.float_)
+    k = jnp.arange(0, 21, dtype=float)
     ak = a**k  # (21,)
     bk = b**k  # (21,)
     # x: (ndim,), expand to (ndim, 1); k: (21,) → broadcast to (ndim, 21)

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "bbob-jax"
-version = "1.6.4"
+version = "1.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "jax" },


### PR DESCRIPTION
## Summary

Release **v1.6.5**. This is a small maintenance release that replaces all uses of the deprecated `jnp.float_` alias with Python's built-in `float` across the source tree, for forward compatibility with newer JAX versions and consistency with the earlier `float32 → float` cleanup.

## Changes

### 🛠 Maintenance
- **Dtype consistency**: Replaced `jnp.float_` with `float` in:
  - `src/bbob_jax/_src/bbob.py` (Gallagher precompute, Katsuura)
  - `src/bbob_jax/_src/cec2005.py` (`f3`, `_elliptic_base`)
  - `src/bbob_jax/_src/registry.py` (conditioned linear transform, nonsingular integer matrix sampler, linear slope makers, CEC2005 conditioned/F12 makers)
  - `src/bbob_jax/_src/utils.py` (`lambda_func`, `bernoulli_vector`, `cec2005_weierstrass`)
- **Imports**: Added `Sequence` to `collections.abc` import in `registry.py`.

### 📦 Release
- Bumped version to **1.6.5** in `pyproject.toml` and `uv.lock`.

## Verification
- No functional/behavioral changes — `float` resolves to the same default JAX dtype as `jnp.float_`.
