### PR TITLE
perf: precompute Gallagher peak rotation, use hard max/min reductions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ The BBOB and CEC 2005 benchmark suites are cornerstones of black-box optimizatio
 
 ## Gradient-friendly implementations
 
-Many BBOB functions use non-smooth operations (`abs`, `sign`, `sqrt`, `max`, `min`) that produce zero, undefined, or infinite gradients at certain points. This library uses [softjax](https://github.com/mvanderSchelling/softjax) straight-through estimators to provide well-defined gradients everywhere while keeping the forward pass *exactly* equal to the original function definitions.
+Many BBOB functions use non-smooth operations (`abs`, `sign`, `sqrt`) that produce zero, undefined, or infinite gradients at certain points. This library uses [softjax](https://github.com/mvanderSchelling/softjax) straight-through estimators to provide well-defined gradients everywhere while keeping the forward pass *exactly* equal to the original function definitions.
 
 For example, `jnp.abs(x)` has a zero gradient at `x = 0` and `jnp.sqrt(x)` has an infinite gradient at `x = 0`. The softjax replacements (`sj.abs_st`, `sj.sqrt`) return the exact same values but route gradients through smooth approximations during the backward pass. This means `jax.grad` produces useful, finite gradients without any loss of benchmark fidelity.
 
@@ -65,8 +65,8 @@ The following operations are replaced:
 | `jnp.sqrt` | `sj.sqrt` | F3, F12, F13, F15, F17, F18, F20 |
 | `jnp.maximum(., 0)` | `sj.relu_st` | F4, F7, F16–F18, F20–F24 (via `penalty`) |
 | `jnp.where` / `>` | `sj.where` / `sj.greater_st` | F3, F6, F12, F15, F17, F18 |
-| `jnp.max` | `sj.max_st` | F21, F22 |
-| `jnp.minimum` | `sj.min_st` | F24 |
+
+softjax is used only where JAX's own gradient is degenerate (zero, undefined, or infinite). Operations with well-defined subgradients — in particular the `max`/`min` reductions in F21, F22, F24 — use plain `jnp.max`/`jnp.min`: their gradient flows through the selected element, which is the meaningful descent direction, and the straight-through soft-sort would otherwise run in every forward pass (the soft branch of `stop_gradient(hard - soft) + soft` cannot be dead-code-eliminated).
 
 Functions that are *intentionally* non-smooth (F7 `step_ellipsoid`, F23 `katsuura`) are left unchanged — smoothing them would defeat their benchmarking purpose.
 

--- a/src/bbob_jax/_src/bbob.py
+++ b/src/bbob_jax/_src/bbob.py
@@ -1049,6 +1049,7 @@ def schwefel_xsinx(
 
 def _precompute_gallagher(
     x_opt: jax.Array,
+    R: jax.Array,
     Q: jax.Array,
     ndim: int,
     num_peaks: int,
@@ -1057,12 +1058,20 @@ def _precompute_gallagher(
     y_minval: float,
     y_maxval: float,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """Precompute Gallagher peak weights and locations.
+    """Precompute Gallagher peak weights and rotated locations.
+
+    Since the same rotation ``R`` applies to every peak difference,
+    ``R @ (x - y_i) == R @ x - R @ y_i``: rotating the peak locations
+    once here lets the evaluation rotate only ``x`` (one ndim^2
+    matvec) instead of all ``num_peaks`` differences
+    (num_peaks * ndim^2).
 
     Parameters
     ----------
     x_opt : jax.Array
         Optimal point for the first peak.
+    R : jax.Array
+        Rotation matrix applied to the peak differences.
     Q : jax.Array
         Rotation matrix (used to seed the RNG).
     ndim : int
@@ -1081,8 +1090,8 @@ def _precompute_gallagher(
     Returns
     -------
     tuple[jax.Array, jax.Array, jax.Array]
-        Peak weights, peak locations, and conditioning
-        diagonal vectors.
+        Peak weights, rotated peak locations (``y @ R.T``), and
+        conditioning diagonal vectors.
     """
     key = jr.key(0)
     key = jr.fold_in(key, Q[0, 0])
@@ -1102,6 +1111,7 @@ def _precompute_gallagher(
         key2, shape=(num_peaks, ndim), minval=y_minval, maxval=y_maxval
     )
     y = y.at[0].set(x_opt)
+    y_rot = y @ R.T
 
     # Compute diagonal vectors instead of full (ndim x ndim) matrices.
     # lambda_func(ndim, alpha_i) = diag(alpha_i^(idx / (2*(ndim-1))))
@@ -1112,7 +1122,7 @@ def _precompute_gallagher(
         alpha[:, None], idx[None, :] / (2 * (ndim - 1))
     ) / jnp.power(alpha[:, None], 0.25)
 
-    return w, y, c_diags
+    return w, y_rot, c_diags
 
 
 def gallagher_101_peaks(
@@ -1122,7 +1132,7 @@ def gallagher_101_peaks(
     R: jax.Array,
     Q: jax.Array,
     _gal_w: jax.Array | None = None,
-    _gal_y: jax.Array | None = None,
+    _gal_y_rot: jax.Array | None = None,
     _gal_c_diags: jax.Array | None = None,
 ) -> jax.Array:
     """Gallagher 101 peaks function (F21).
@@ -1148,8 +1158,9 @@ def gallagher_101_peaks(
         Second rotation matrix.
     _gal_w : jax.Array, optional
         Precomputed peak weight vector of shape (101,).
-    _gal_y : jax.Array, optional
-        Precomputed peak location matrix of shape (101, ndim).
+    _gal_y_rot : jax.Array, optional
+        Precomputed rotated peak location matrix ``y @ R.T`` of shape
+        (101, ndim).
     _gal_c_diags : jax.Array, optional
         Precomputed conditioning diagonal vectors of shape (101, ndim).
 
@@ -1161,22 +1172,23 @@ def gallagher_101_peaks(
     ndim = x.shape[-1]
 
     if _gal_w is None:
-        w, y, c_diags = _precompute_gallagher(
-            x_opt, Q, ndim, 101, 99, 1000.0, -5.0, 5.0
+        w, y_rot, c_diags = _precompute_gallagher(
+            x_opt, R, Q, ndim, 101, 99, 1000.0, -5.0, 5.0
         )
     else:
-        assert _gal_y is not None
+        assert _gal_y_rot is not None
         assert _gal_c_diags is not None
-        w, y, c_diags = _gal_w, _gal_y, _gal_c_diags
+        w, y_rot, c_diags = _gal_w, _gal_y_rot, _gal_c_diags
 
-    diff = x[None, :] - y  # (101, ndim)
-    rotated_diff = jnp.einsum("ij,...j->...i", R, diff)  # (101, ndim)
+    # R @ (x - y_i) == R @ x - (y @ R.T)_i: rotate x once instead of
+    # all 101 differences.
+    rotated_diff = R @ x - y_rot  # (101, ndim)
     exponents = -(1.0 / (2.0 * ndim)) * jnp.sum(
         c_diags * rotated_diff**2, axis=-1
     )  # (101,)
     inside_max = w * jnp.exp(exponents)  # (101,)
 
-    f = 10.0 - sj.max_st(inside_max, axis=0)
+    f = 10.0 - jnp.max(inside_max, axis=0)
 
     f_tosz = tosz_func(jnp.array([f]))[0]
 
@@ -1192,7 +1204,7 @@ def gallagher_21_peaks(
     R: jax.Array,
     Q: jax.Array,
     _gal_w: jax.Array | None = None,
-    _gal_y: jax.Array | None = None,
+    _gal_y_rot: jax.Array | None = None,
     _gal_c_diags: jax.Array | None = None,
 ) -> jax.Array:
     """Gallagher 21 peaks function (F22).
@@ -1218,8 +1230,9 @@ def gallagher_21_peaks(
         Second rotation matrix.
     _gal_w : jax.Array, optional
         Precomputed peak weight vector of shape (21,).
-    _gal_y : jax.Array, optional
-        Precomputed peak location matrix of shape (21, ndim).
+    _gal_y_rot : jax.Array, optional
+        Precomputed rotated peak location matrix ``y @ R.T`` of shape
+        (21, ndim).
     _gal_c_diags : jax.Array, optional
         Precomputed conditioning diagonal vectors of shape (21, ndim).
 
@@ -1231,22 +1244,23 @@ def gallagher_21_peaks(
     ndim = x.shape[-1]
 
     if _gal_w is None:
-        w, y, c_diags = _precompute_gallagher(
-            x_opt, Q, ndim, 21, 19, 1000.0**2, -4.9, 4.9
+        w, y_rot, c_diags = _precompute_gallagher(
+            x_opt, R, Q, ndim, 21, 19, 1000.0**2, -4.9, 4.9
         )
     else:
-        assert _gal_y is not None
+        assert _gal_y_rot is not None
         assert _gal_c_diags is not None
-        w, y, c_diags = _gal_w, _gal_y, _gal_c_diags
+        w, y_rot, c_diags = _gal_w, _gal_y_rot, _gal_c_diags
 
-    diff = x[None, :] - y  # (21, ndim)
-    rotated_diff = jnp.einsum("ij,...j->...i", R, diff)  # (21, ndim)
+    # R @ (x - y_i) == R @ x - (y @ R.T)_i: rotate x once instead of
+    # all 21 differences.
+    rotated_diff = R @ x - y_rot  # (21, ndim)
     exponents = -(1.0 / (2.0 * ndim)) * jnp.sum(
         c_diags * rotated_diff**2, axis=-1
     )  # (21,)
     inside_max = w * jnp.exp(exponents)  # (21,)
 
-    f = 10.0 - sj.max_st(inside_max, axis=0)
+    f = 10.0 - jnp.max(inside_max, axis=0)
 
     f_tosz = tosz_func(jnp.array([f]))[0]
 
@@ -1386,7 +1400,7 @@ def lunacek_bi_rastrigin(
 
     z = _mat @ (x_hat - mu0 * jnp.ones_like(x))
 
-    term1 = sj.min_st(
+    term1 = jnp.min(
         jnp.stack(
             [
                 jnp.sum(jnp.power(x_hat - mu0, 2)),

--- a/src/bbob_jax/_src/cec2005.py
+++ b/src/bbob_jax/_src/cec2005.py
@@ -223,7 +223,7 @@ def f5(
         Function value(s).
     """
     diff = R @ (x - x_opt)
-    return cast(jax.Array, sj.max_st(sj.abs_st(diff)) + f_opt)
+    return cast(jax.Array, jnp.max(sj.abs_st(diff)) + f_opt)
 
 
 def f6(

--- a/src/bbob_jax/_src/registry.py
+++ b/src/bbob_jax/_src/registry.py
@@ -420,8 +420,9 @@ def _make_gallagher_randomized(
     """Randomized factory for Gallagher peak functions."""
     partial_fn, f_opt_val = make_randomized(fn, ndim, key)
     kw = _partial_keywords(partial_fn)
-    w, y, c_diags = _precompute_gallagher(
+    w, y_rot, c_diags = _precompute_gallagher(
         kw["x_opt"],
+        kw["R"],
         kw["Q"],
         ndim,
         num_peaks,
@@ -437,7 +438,7 @@ def _make_gallagher_randomized(
         R=kw["R"],
         Q=kw["Q"],
         _gal_w=w,
-        _gal_y=y,
+        _gal_y_rot=y_rot,
         _gal_c_diags=c_diags,
     ), f_opt_val
 
@@ -455,8 +456,9 @@ def _make_gallagher_deterministic(
     """Deterministic factory for Gallagher peak functions."""
     partial_fn, f_opt_val = make_determinstic(fn, ndim)
     kw = _partial_keywords(partial_fn)
-    w, y, c_diags = _precompute_gallagher(
+    w, y_rot, c_diags = _precompute_gallagher(
         kw["x_opt"],
+        kw["R"],
         kw["Q"],
         ndim,
         num_peaks,
@@ -472,7 +474,7 @@ def _make_gallagher_deterministic(
         R=kw["R"],
         Q=kw["Q"],
         _gal_w=w,
-        _gal_y=y,
+        _gal_y_rot=y_rot,
         _gal_c_diags=c_diags,
     ), f_opt_val
 

--- a/tests/test_gallagher_equivalence.py
+++ b/tests/test_gallagher_equivalence.py
@@ -1,0 +1,116 @@
+"""Equivalence tests for the Gallagher rotation precompute.
+
+The Gallagher functions rotate the peak locations once at factory time
+(``y @ R.T``) and rotate only ``x`` per evaluation, instead of rotating
+all ``num_peaks`` differences. This is algebraically identical
+(``R @ (x - y_i) == R @ x - R @ y_i``); these tests pin values and
+gradients against a reference implementation that rotates every peak
+difference explicitly, as the pre-refactor code did. The reference is a
+deliberately independent re-implementation and lives only in tests.
+"""
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+import bbob_jax
+from bbob_jax._src.utils import penalty, tosz_func
+
+GALLAGHER_PARAMS = {
+    "gallagher_101_peaks": (101, 99, 1000.0, -5.0, 5.0),
+    "gallagher_21_peaks": (21, 19, 1000.0**2, -4.9, 4.9),
+}
+
+
+def _reference_gallagher(
+    x,
+    x_opt,
+    f_opt,
+    R,
+    Q,
+    num_peaks,
+    w_divisor,
+    alpha_first,
+    y_minval,
+    y_maxval,
+):
+    """Pre-refactor Gallagher: rotate every peak difference explicitly."""
+    ndim = x.shape[-1]
+
+    key = jr.key(0)
+    key = jr.fold_in(key, Q[0, 0])
+    key1, key2 = jr.split(key)
+
+    i = jnp.arange(1, num_peaks + 1, dtype=float)
+    j = jnp.arange(0, num_peaks - 1, dtype=float)
+
+    w = 1.1 + 8.0 * ((i - 2) / w_divisor)
+    w = w.at[0].set(10.0)
+
+    a = jnp.power(1000, 2.0 * (j / (num_peaks - 1)))
+    alpha = jr.permutation(key1, a)
+    alpha = jnp.concatenate([jnp.array([alpha_first]), alpha])
+
+    y = jr.uniform(
+        key2, shape=(num_peaks, ndim), minval=y_minval, maxval=y_maxval
+    )
+    y = y.at[0].set(x_opt)
+
+    idx = jnp.arange(ndim, dtype=float)
+    c_diags = jnp.power(
+        alpha[:, None], idx[None, :] / (2 * (ndim - 1))
+    ) / jnp.power(alpha[:, None], 0.25)
+
+    diff = x[None, :] - y  # (num_peaks, ndim)
+    rotated_diff = jnp.einsum("ij,...j->...i", R, diff)  # (num_peaks, ndim)
+    exponents = -(1.0 / (2.0 * ndim)) * jnp.sum(
+        c_diags * rotated_diff**2, axis=-1
+    )
+    inside_max = w * jnp.exp(exponents)
+
+    f = 10.0 - jnp.max(inside_max, axis=0)
+    f_tosz = tosz_func(jnp.array([f]))[0]
+    return jnp.power(f_tosz, 2) + penalty(x) + f_opt
+
+
+@pytest.mark.parametrize("name", list(GALLAGHER_PARAMS))
+@pytest.mark.parametrize(
+    "registry", [bbob_jax.registry, bbob_jax.registry_original]
+)
+@pytest.mark.parametrize("dim", [2, 10, 40])
+def test_gallagher_matches_per_peak_rotation(name, registry, dim):
+    fn, _ = registry[name](ndim=dim, key=jr.key(3))
+    ref_kwargs = {k: fn.keywords[k] for k in ("x_opt", "f_opt", "R", "Q")}
+    num_peaks, w_divisor, alpha_first, y_minval, y_maxval = GALLAGHER_PARAMS[
+        name
+    ]
+
+    def ref(x):
+        return _reference_gallagher(
+            x,
+            num_peaks=num_peaks,
+            w_divisor=w_divisor,
+            alpha_first=alpha_first,
+            y_minval=y_minval,
+            y_maxval=y_maxval,
+            **ref_kwargs,
+        )
+
+    x = jr.uniform(jr.key(7), (32, dim), minval=-5.0, maxval=5.0)
+
+    value_new = jax.vmap(fn)(x)
+    value_ref = jax.vmap(ref)(x)
+    assert jnp.allclose(value_new, value_ref, rtol=1e-4, atol=1e-5), (
+        f"{name} (dim={dim}): max value deviation "
+        f"{jnp.max(jnp.abs(value_new - value_ref))} from the per-peak "
+        f"rotation reference"
+    )
+
+    grad_new = jax.vmap(jax.grad(fn))(x)
+    grad_ref = jax.vmap(jax.grad(ref))(x)
+    assert jnp.allclose(grad_new, grad_ref, rtol=1e-3, atol=1e-4), (
+        f"{name} (dim={dim}): max gradient deviation "
+        f"{jnp.max(jnp.abs(grad_new - grad_ref))} from the per-peak "
+        f"rotation reference"
+    )


### PR DESCRIPTION
## Why the Gallagher functions were slow

Two compounding causes, unique to F21/F22:

1. **Per-eval rotation of all peaks.** `jnp.einsum("ij,...j->...i", R, diff)` rotated all 101 (resp. 21) peak differences on every evaluation: `num_peaks * ndim^2` MACs (~161k at 40D) vs O(ndim) for separable functions. Since the same `R` applies to every peak, `R @ (x - y_i) == R @ x - R @ y_i` — the peak locations are now rotated **once at factory time** (`_precompute_gallagher` returns `y @ R.T`) and only `x` is rotated per evaluation: `ndim^2 + num_peaks * ndim` (~5.6k MACs at 40D, ~28x less).

2. **`sj.max_st` runs its soft-sort in every forward pass.** softjax's straight-through decorator returns `stop_gradient(hard - soft) + soft`, so the smooth branch (a sort + cumsum simplex projection over the peaks) executes even for value-only callers and cannot be dead-code-eliminated by XLA; differentiating it also dominated grad-compile time. `max`/`min` have well-defined subgradients (the gradient flows through the winning peak — the meaningful descent direction), so the four sort-backed reduction sites (F21, F22, F24 `min`, CEC F5) now use plain `jnp.max`/`jnp.min`. All elementwise softjax usage (`sign`, `round`, `abs`, `sqrt`, `heaviside`, ...) is untouched — that is where JAX's own gradient is genuinely degenerate. `docs/index.md` now states this convention.

## Measured impact (CPU, jitted, batch 256, d=40, median of 30)

| Function | value (ms) | grad (ms) | grad-compile (ms) |
|---|---:|---:|---:|
| `gallagher_101_peaks` | 0.65 → 0.41–0.51 | **1.08 → 0.45** | **112 → 63** |
| `gallagher_21_peaks` | 0.33 → 0.17 | 0.48 → 0.29 | 106 → 66 |
| `cec2005/f5` | 0.14 → 0.08 | 0.14 → 0.08 | 89 → 34 |
| `rastrigin` (control) | 0.26 → 0.24 | 0.42 → 0.42 | 82 → 84 |

`gallagher_101_peaks` grad now sits at rastrigin's level (0.45 vs 0.42 ms) instead of 2.5x above it.

## Semantics

- **Values**: unchanged up to float reassociation (~1e-7 relative in f32); the straight-through forward was already the hard max, so the max swap is value-exact.
- **Gradients**: F21/F22/F24/CEC-F5 gradients now flow only through the selected peak/element instead of softly blending near basin boundaries; away from boundaries the two agree. Suggest a **minor version bump** when releasing.
- `tests/test_gallagher_equivalence.py` pins values *and* gradients against an independent per-peak-rotation reference (both registries, d = 2/10/40).
- Full suite: 1874 passed, 55 skipped.

## Post-fix sweep of all 49 functions (same setup, sorted by grad time)

Confirms gallagher is back in family; the remaining top tier is exclusively the CEC 2005 composition functions (f15–f25), which evaluate 10 sub-functions each by construction — expected, possible follow-up (their grad-compile at 270–590 ms is the more interesting target there).

<details><summary>Full table</summary>

| Function | value (ms) | grad (ms) | grad-compile (ms) |
|---|---:|---:|---:|
| `cec2005/f22` | 1.809 | 2.886 | 346 |
| `cec2005/f15` | 1.359 | 2.798 | 312 |
| `cec2005/f16` | 1.323 | 2.746 | 270 |
| `cec2005/f21` | 1.585 | 2.713 | 391 |
| `cec2005/f17` | 1.372 | 2.506 | 327 |
| `cec2005/f23` | 1.542 | 2.156 | 401 |
| `cec2005/f20` | 0.791 | 2.135 | 273 |
| `cec2005/f18` | 0.805 | 2.126 | 326 |
| `cec2005/f25` | 1.099 | 2.043 | 591 |
| `cec2005/f19` | 0.809 | 2.041 | 267 |
| `cec2005/f24` | 1.143 | 2.032 | 583 |
| `cec2005/f12` | 0.564 | 0.739 | 42 |
| `bbob/weierstrass` | 0.393 | 0.727 | 73 |
| `bbob/schaffer_f7_condition_10` | 0.258 | 0.457 | 78 |
| `bbob/schaffer_f7_condition_1000` | 0.255 | 0.449 | 83 |
| `bbob/gallagher_101_peaks` | 0.265 | 0.442 | 62 |
| `bbob/rastrigin` | 0.240 | 0.423 | 130 |
| `bbob/rastrigin_seperable` | 0.243 | 0.401 | 88 |
| `cec2005/f11` | 0.562 | 0.340 | 40 |
| `bbob/gallagher_21_peaks` | 0.184 | 0.288 | 66 |
| `bbob/skew_rastrigin_bueche` | 0.233 | 0.273 | 92 |
| `bbob/katsuura` | 0.167 | 0.240 | 66 |
| `cec2005/f7` | 0.082 | 0.238 | 51 |
| `bbob/bent_cigar` | 0.142 | 0.230 | 59 |
| `bbob/discuss` | 0.145 | 0.197 | 59 |
| `cec2005/f4` | 0.117 | 0.190 | 48 |
| `bbob/lunacek_bi_rastrigin` | 0.159 | 0.174 | 54 |
| `bbob/ellipsoid` | 0.130 | 0.169 | 51 |
| `bbob/schwefel_xsinx` | 0.114 | 0.158 | 51 |
| `cec2005/f14` | 0.083 | 0.150 | 46 |
| `bbob/step_ellipsoid` | 0.134 | 0.150 | 48 |
| `bbob/griewank_rosenbrock_f8f2` | 0.118 | 0.147 | 32 |
| `cec2005/f2` | 0.113 | 0.143 | 35 |
| `bbob/ellipsoid_seperable` | 0.138 | 0.142 | 59 |
| `cec2005/f13` | 0.087 | 0.137 | 46 |
| `bbob/sum_of_different_powers` | 0.121 | 0.136 | 32 |
| `cec2005/f8` | 0.085 | 0.134 | 34 |
| `bbob/attractive_sector` | 0.101 | 0.106 | 62 |
| `bbob/rosenbrock_rotated` | 0.055 | 0.088 | 30 |
| `cec2005/f10` | 0.077 | 0.086 | 25 |
| `cec2005/f5` | 0.079 | 0.078 | 34 |
| `bbob/sharp_ridge` | 0.057 | 0.068 | 37 |
| `bbob/rosenbrock` | 0.063 | 0.068 | 26 |
| `cec2005/f3` | 0.058 | 0.066 | 28 |
| `cec2005/f6` | 0.060 | 0.064 | 27 |
| `cec2005/f9` | 0.062 | 0.059 | 19 |
| `bbob/sphere` | 0.046 | 0.041 | 24 |
| `bbob/linear_slope` | 0.042 | 0.038 | 19 |
| `cec2005/f1` | 0.042 | 0.038 | 22 |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
