### PR TITLE
CEC 2017 wave 1/3: simple functions F1, F3–F10 + min_ndim plumbing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`bbob-jax` is a JAX implementation of the 24 BBOB (Black-Box Optimization Benchmark) noise-free functions and the 25 CEC 2005 benchmark functions. The key value-add over the original C implementations is full JAX compatibility: automatic differentiation, JIT compilation, and vectorization via `vmap`.
+`bbob-jax` is a JAX implementation of the 24 BBOB (Black-Box Optimization Benchmark) noise-free functions, the 25 CEC 2005 benchmark functions, and the CEC 2017 bound-constrained suite (in progress: F1, F3–F10 landed; hybrids F11–F20 and compositions F21–F30 follow; F2 was officially withdrawn and is skipped). The key value-add over the original C implementations is full JAX compatibility: automatic differentiation, JIT compilation, and vectorization via `vmap`.
 
 ## Commands
 
@@ -28,9 +28,11 @@ make docs                  # Start MkDocs dev server
 - `registry_original` — deterministic BBOB factory (zero x_opt, zero f_opt, identity rotations)
 - `cec2005_registry` — randomized CEC 2005 factory (25 functions `f1`–`f25`)
 - `cec2005_registry_original` — deterministic CEC 2005 factory
+- `cec2017_registry` / `cec2017_registry_original` — CEC 2017 factories (names `cec2017_f1`, `cec2017_f3`…; prefixed because `SPEC_BY_NAME` is a single namespace and CEC 2005 owns the bare `fN` keys)
 - `function_characteristics` — BBOB metadata dict (separable/unimodal flags per function)
 - `cec2005_function_characteristics` — CEC 2005 metadata dict
-- `bbob_bounds` / `cec2005_bounds` — per-function search-space bounds (also via the `bounds` submodule)
+- `cec2017_function_characteristics` — CEC 2017 metadata dict (`unimodal`/`multimodal`/`hybrid`/`composition`/`rotated`/`structure_modified`; no `noise` key)
+- `bbob_bounds` / `cec2005_bounds` / `cec2017_bounds` — per-function search-space bounds (also via the `bounds` submodule)
 
 ### Spec Table (single source of truth)
 
@@ -64,11 +66,14 @@ p.fn, p.x_opt, p.f_opt, p.bounds, p.tags, p.noisy
 ```
 `fn(p.x_opt) == p.f_opt` holds for every function (documented exceptions:
 deterministic CEC compositions are degenerate). Noisy CEC functions
-(`noise` tag) are called as `fn(x, key)`.
+(`noise` tag) are called as `fn(x, key)`. `Problem.min_ndim` is the
+smallest supported dimension (default 1); makers raise `ValueError` below
+it (e.g. `cec2017_f6` needs `ndim >= 2`, CEC 2017 hybrids will need one
+dimension per subcomponent kernel).
 
 ### Core Function Signature
 
-All 24 BBOB functions in `_src/bbob.py` and the 25 CEC 2005 functions in `_src/cec2005.py` share the internal signature:
+All 24 BBOB functions in `_src/bbob.py`, the 25 CEC 2005 functions in `_src/cec2005.py` and the CEC 2017 functions in `_src/cec2017.py` share the internal signature:
 ```python
 def fn(x, x_opt, f_opt, R, Q) -> jax.Array
 ```
@@ -96,17 +101,19 @@ src/bbob_jax/
 └── _src/
     ├── bbob.py          # All 24 BBOB function implementations
     ├── cec2005.py       # All 25 CEC 2005 function implementations (f1–f25)
+    ├── cec2017.py       # CEC 2017 function implementations (F2 withdrawn/skipped)
     ├── spec.py          # FunctionSpec table — single source of truth per function
     ├── factories.py     # Mode-parameterized makers (deterministic= flag)
-    ├── registry.py      # The four registry dicts, derived from spec.py
+    ├── registry.py      # The six registry dicts, derived from spec.py
     ├── problem.py       # Problem record + problem() accessor
     ├── transforms.py    # BBOB transforms: tosz, tasy, lambda, penalty
-    ├── composition.py   # CEC kernels + hybrid composition machinery
+    ├── composition.py   # CEC kernels (2005 + 2017) + hybrid composition machinery
     ├── sampling.py      # fopt, xopt, bernoulli_vector, rotation_matrix
     ├── mesh.py          # _create_mesh grid evaluator (matplotlib-free)
     ├── tags.py          # function_characteristics, derived from spec.py
     ├── cec2005_tags.py  # cec2005_function_characteristics, derived from spec.py
-    ├── bounds.py        # bbob_bounds, cec2005_bounds, derived from spec.py
+    ├── cec2017_tags.py  # cec2017_function_characteristics, derived from spec.py
+    ├── bounds.py        # bbob_bounds, cec2005_bounds, cec2017_bounds, derived from spec.py
     └── plotting.py      # plot_2d, plot_3d (requires optional matplotlib dep)
 ```
 
@@ -114,12 +121,13 @@ Architecture decisions are recorded in `docs/adr/`.
 
 ### Testing
 
-Tests live in `tests/` (`test_example.py` for BBOB, `test_cec2005.py` for CEC 2005, plus `test_bounds.py`, `test_composition.py`, `test_problem.py`, `test_consistency.py`, `test_gallagher_equivalence.py`). They are parametrized over all functions × multiple dimensions × both registries. Each test validates:
+Tests live in `tests/` (`test_example.py` for BBOB, `test_cec2005.py` for CEC 2005, `test_cec2017.py` for CEC 2017, plus `test_bounds.py`, `test_composition.py`, `test_problem.py`, `test_consistency.py`, `test_gallagher_equivalence.py`). They are parametrized over all functions × multiple dimensions × both registries. Each test validates:
 - Correct scalar output shape
 - JIT compilation (`jax.jit`)
 - Vectorization (`jax.vmap`)
 - Gradient computation (`jax.grad`)
-- `fn(x_opt) == f_opt` for both suites via `problem()` (`test_problem.py`)
+- NaN propagation (NaN in → NaN out) for BBOB and CEC 2017
+- `fn(x_opt) == f_opt` for all suites via `problem()` (`test_problem.py`)
 - Registry/tags/bounds key-set consistency and tag schemas (`test_consistency.py`)
 
 `matplotlib` is an optional dependency (install group `plot`); tests don't require it.

--- a/src/bbob_jax/__init__.py
+++ b/src/bbob_jax/__init__.py
@@ -33,12 +33,15 @@ from bbob_jax._src.bbob import (
     sum_of_different_powers,
     weierstrass,
 )
-from bbob_jax._src.bounds import bbob_bounds, cec2005_bounds
+from bbob_jax._src.bounds import bbob_bounds, cec2005_bounds, cec2017_bounds
 from bbob_jax._src.cec2005_tags import cec2005_function_characteristics
+from bbob_jax._src.cec2017_tags import cec2017_function_characteristics
 from bbob_jax._src.problem import Problem, problem
 from bbob_jax._src.registry import (
     cec2005_registry,
     cec2005_registry_original,
+    cec2017_registry,
+    cec2017_registry_original,
     registry,
     registry_original,
 )
@@ -61,8 +64,12 @@ __all__ = [
     "cec2005_registry",
     "cec2005_registry_original",
     "cec2005_function_characteristics",
+    "cec2017_registry",
+    "cec2017_registry_original",
+    "cec2017_function_characteristics",
     "bbob_bounds",
     "cec2005_bounds",
+    "cec2017_bounds",
     "Problem",
     "problem",
     "attractive_sector",

--- a/src/bbob_jax/_src/cec2017.py
+++ b/src/bbob_jax/_src/cec2017.py
@@ -1,0 +1,393 @@
+"""CEC 2017 benchmark functions implemented in JAX.
+
+IMPORTANT: This implementation targets parity with the official reference
+code ``cec17_test_func.c`` (Awad et al., 2016, "Problem Definitions and
+Evaluation Criteria for the CEC 2017 Special Session and Competition on
+Single Objective Real-Parameter Numerical Optimization"). Where the report
+and the reference code disagree, the code wins — that is what published
+results were produced with — and the divergence is documented in the
+function's docstring. Parameters (shift vectors, rotation matrices) are
+generated from seeds rather than loaded from the official data files, and
+the per-function bias values ``F_i* = 100 * i`` are replaced by a sampled
+``f_opt``. Results will NOT match published CEC 2017 benchmarking results.
+
+F2 (Sum of Different Powers) was officially withdrawn from the competition
+because of unstable behavior at higher dimensions and is not implemented;
+the numbering keeps the hole (``f1``, ``f3`` .. ``f30``), matching the
+reference code and data files. The "final version updated" report renumbers
+the remaining functions 1-29 — that renumbering is NOT followed here.
+
+All functions share the internal signature ``fn(x, x_opt, f_opt, R, Q)``
+(``Q`` is unused by the simple functions F1-F10) and are exposed through
+``cec2017_registry`` / ``cec2017_registry_original`` after partial
+application, with search range ``[-100, 100]^D`` and shifts sampled in
+``[-80, 80]^D`` as in the official suite.
+"""
+
+import math
+
+import jax
+import jax.numpy as jnp
+
+from bbob_jax._src.composition import (
+    cec_bent_cigar,
+    cec_rastrigin,
+    cec_rosenbrock,
+    levy,
+    modified_schwefel,
+    schaffer_f7,
+    zakharov,
+)
+
+__author__ = "Martin van der Schelling (M.P.vanderSchelling@tudelft.nl)"
+__credits__ = ["Martin van der Schelling"]
+__status__ = "Stable"
+
+
+def f1(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted and Rotated Bent Cigar (F1).
+
+    Unimodal, non-separable, smooth but narrow ridge.
+    ``z = R @ (x - x_opt)``, no shrink.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    z = R @ (x - x_opt)
+    return cec_bent_cigar(z) + f_opt
+
+
+def f3(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted and Rotated Zakharov (F3).
+
+    Unimodal, non-separable. ``z = R @ (x - x_opt)``, no shrink.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    z = R @ (x - x_opt)
+    return zakharov(z) + f_opt
+
+
+def f4(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted and Rotated Rosenbrock (F4).
+
+    Multimodal (for D > 3), non-separable.
+    ``z = R @ (2.048/100 * (x - x_opt))`` with the kernel's
+    ``+1`` re-centering so the minimum stays at ``x_opt``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    z = R @ ((2.048 / 100.0) * (x - x_opt))
+    return cec_rosenbrock(z) + f_opt
+
+
+def f5(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted and Rotated Rastrigin (F5).
+
+    Multimodal, non-separable, huge number of local optima.
+    ``z = R @ (5.12/100 * (x - x_opt))``. The report's equation
+    omits the shrink; the reference code applies ``5.12/100``
+    (code wins).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    z = R @ ((5.12 / 100.0) * (x - x_opt))
+    return cec_rastrigin(z) + f_opt
+
+
+def f6(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted Schaffer's F7 (F6). Needs ``ndim >= 2``.
+
+    Multimodal, asymmetrical. The report defines this slot as
+    ``f_schafferF7(M(0.5/100 * (x - o)))``, but in the reference
+    code the kernel reads the pre-rotation global ``y = x - o``
+    with shrink rate 1.0 — the rotation matrix is computed and
+    then never used, and no shrink is applied. Code wins:
+    this function is shifted only (``rotated=False`` tag), with
+    no shrink. ``R`` and ``Q`` are accepted but unused.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused; dead in the reference code).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = x - x_opt
+    return schaffer_f7(y) + f_opt
+
+
+def f7(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted and Rotated Lunacek Bi-Rastrigin (F7).
+
+    Multimodal, asymmetrical, two funnels. Ported from
+    ``bi_rastrigin_func`` in the reference code: ``y = 10/100 *
+    (x - x_opt)``, doubled and sign-flipped where the *shift*
+    coordinate is negative (a static, per-instance flip), the
+    two funnel terms are computed on the unrotated variable and
+    only the cosine term sees the rotation. The report's outer
+    ``600/100`` scale (eq. 25) double-counts the basic
+    function's internal ``10/100``; the code applies ``10/100``
+    once (code wins). The ``min`` of the funnel terms uses
+    ``jnp.minimum`` (well-defined subgradient).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (applied to the cosine term only).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    ndim = x.shape[-1]
+    mu0 = 2.5
+    d = 1.0
+    s = 1.0 - 1.0 / (2.0 * math.sqrt(ndim + 20.0) - 8.2)
+    mu1 = -math.sqrt((mu0**2 - d) / s)
+
+    y = (10.0 / 100.0) * (x - x_opt)
+    flip = jnp.where(x_opt < 0.0, -1.0, 1.0)
+    t = 2.0 * flip * y
+    funnel0 = jnp.sum(t**2)
+    funnel1 = d * ndim + s * jnp.sum((t + (mu0 - mu1)) ** 2)
+    t_rot = R @ t
+    cos_term = 10.0 * (ndim - jnp.sum(jnp.cos(2.0 * jnp.pi * t_rot)))
+    return jnp.minimum(funnel0, funnel1) + cos_term + f_opt
+
+
+def f8(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted and Rotated "Non-Continuous" Rastrigin (F8).
+
+    Multimodal, non-separable. The report's basic definition
+    includes a non-continuity rounding step plus ``tosz``/
+    ``tasy``/conditioning transforms, but in the reference code
+    the rounding loop operates on a stale global buffer *before*
+    it is overwritten and none of the transforms appear — the
+    function actually computed (and used for all published
+    results) is plain shifted-rotated Rastrigin,
+    ``z = R @ (5.12/100 * (x - x_opt))``, identical in structure
+    to F5. Code wins; only the sampled instance differs from F5.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    z = R @ ((5.12 / 100.0) * (x - x_opt))
+    return cec_rastrigin(z) + f_opt
+
+
+def f9(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted and Rotated Levy (F9).
+
+    Multimodal, huge number of local optima. ``z = R @ (x -
+    x_opt)``; the report says shrink ``5.12/100`` but the
+    reference code applies none (code wins). NOTE: the Levy
+    kernel's minimum is at all-ones, not the origin, so the
+    global minimizer is ``x_opt + R.T @ ones`` — NOT the sampled
+    shift (the same is true of the official suite, where
+    ``F9(o_9) != 900``). The ``x_opt_from`` resolver in
+    ``spec.py`` accounts for this; the minimizer can fall
+    outside ``[-100, 100]`` only for shifts within ``sqrt(D)``
+    of the boundary (shifts are sampled in ``[-80, 80]``).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    z = R @ (x - x_opt)
+    return levy(z) + f_opt
+
+
+def f10(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Shifted and Rotated Modified Schwefel (F10).
+
+    Multimodal, huge number of local optima, second-best
+    optimum far from the global one.
+    ``z = R @ (1000/100 * (x - x_opt))``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    z = R @ (10.0 * (x - x_opt))
+    return modified_schwefel(z) + f_opt

--- a/src/bbob_jax/_src/cec2017_tags.py
+++ b/src/bbob_jax/_src/cec2017_tags.py
@@ -1,19 +1,19 @@
-"""Search-space bounds for BBOB, CEC 2005 and CEC 2017 benchmarks.
+"""CEC 2017 function characteristics metadata.
 
+Maps each CEC 2017 function name to a dict with boolean flags
+``unimodal``, ``multimodal``, ``hybrid``, ``composition``,
+``rotated`` and ``structure_modified`` (see ``_cec2017_tags``
+in ``spec.py`` for the schema; unlike CEC 2005 there is no
+``noise`` key — the suite has no stochastic functions).
 Derived from the :class:`~bbob_jax._src.spec.FunctionSpec`
-table in ``spec.py``.
+table; a lookup with an unknown name raises ``KeyError``.
 """
 
 #                                                                       Modules
 # =============================================================================
 
 # Local
-from bbob_jax._src.spec import (
-    BBOB_BOUNDS,
-    BBOB_SPECS,
-    CEC2005_SPECS,
-    CEC2017_SPECS,
-)
+from bbob_jax._src.spec import CEC2017_SPECS
 
 #                                                          Authorship & Credits
 # =============================================================================
@@ -22,16 +22,6 @@ __credits__ = ["Martin van der Schelling"]
 __status__ = "Stable"
 # =============================================================================
 
-__all__ = ["BBOB_BOUNDS", "bbob_bounds", "cec2005_bounds", "cec2017_bounds"]
-
-bbob_bounds: dict[str, tuple[float, float]] = {
-    s.name: s.bounds for s in BBOB_SPECS
-}
-
-cec2005_bounds: dict[str, tuple[float, float]] = {
-    s.name: s.bounds for s in CEC2005_SPECS
-}
-
-cec2017_bounds: dict[str, tuple[float, float]] = {
-    s.name: s.bounds for s in CEC2017_SPECS
+cec2017_function_characteristics: dict[str, dict[str, bool]] = {
+    s.name: dict(s.tags) for s in CEC2017_SPECS
 }

--- a/src/bbob_jax/_src/composition.py
+++ b/src/bbob_jax/_src/composition.py
@@ -1,11 +1,20 @@
-"""CEC 2005 component kernels and hybrid-composition machinery.
+"""CEC component kernels and hybrid-composition machinery.
 
 Provides the base kernels used inside the CEC 2005 functions
 (``ackley``, ``griewank``, ``scaffer_f6``,
-``cec2005_weierstrass``) and the differentiable hybrid
-composition used by F15-F25, plus its ``_f_max``
-precomputation. Used by the CEC 2005 suite only; the BBOB
+``cec2005_weierstrass``) and the CEC 2017 functions
+(``cec_bent_cigar``, ``zakharov``, ``cec_rosenbrock``,
+``cec_rastrigin``, ``schaffer_f7``, ``levy``,
+``modified_schwefel``), plus the differentiable CEC 2005
+hybrid composition used by F15-F25 and its ``_f_max``
+precomputation. Used by the CEC suites only; the BBOB
 transformations live in ``transforms.py``.
+
+Kernel convention: bare ``(ndim,) -> scalar`` functions with
+minimum 0 at the origin (exception: ``levy``, whose minimum
+is at all-ones — see its docstring). NaN inputs propagate to
+the output; ``sqrt`` calls carry a small epsilon instead of
+using ``sj.sqrt`` because the latter maps NaN to 0.
 """
 
 #                                                                       Modules
@@ -128,6 +137,198 @@ def cec2005_weierstrass(x: jax.Array) -> jax.Array:
     # Per-element difference avoids catastrophic cancellation at z=0
     cos_ref = ak * jnp.cos(jnp.pi * bk)  # (21,)
     return jnp.sum(cos_terms - cos_ref[None, :])
+
+
+#                                                             CEC 2017 kernels
+# =============================================================================
+# Ground truth is the official cec17_test_func.c ("code wins" over the report
+# where they disagree); each function in cec2017.py documents its divergences.
+# Names clashing with the full BBOB functions in bbob.py carry a ``cec_``
+# prefix (cf. ``cec2005_weierstrass``).
+
+
+def cec_bent_cigar(x: jax.Array) -> jax.Array:
+    """Bent Cigar kernel. Minimum 0 at origin.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    return x[0] ** 2 + 1e6 * jnp.sum(x[1:] ** 2)
+
+
+def zakharov(x: jax.Array) -> jax.Array:
+    """Zakharov kernel. Minimum 0 at origin.
+
+    ``sum(x^2) + s^2 + s^4`` with ``s = sum(0.5 * i * x_i)``
+    (1-based ``i``). Unimodal.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    ndim = x.shape[-1]
+    weights = 0.5 * jnp.arange(1, ndim + 1, dtype=x.dtype)
+    s = jnp.sum(weights * x)
+    return jnp.sum(jnp.square(x)) + s**2 + s**4
+
+
+def cec_rosenbrock(x: jax.Array) -> jax.Array:
+    """Rosenbrock kernel with the CEC ``+1`` re-centering.
+
+    Evaluates the classic Rosenbrock at ``w = x + 1`` so the
+    minimum 0 sits at the origin (the reference code's
+    "shift to origin").
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    w = x + 1.0
+    return jnp.sum(100.0 * (w[:-1] ** 2 - w[1:]) ** 2 + (w[:-1] - 1.0) ** 2)
+
+
+def cec_rastrigin(x: jax.Array) -> jax.Array:
+    """Rastrigin kernel. Minimum 0 at origin.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    return jnp.sum(jnp.square(x) - 10.0 * jnp.cos(2.0 * jnp.pi * x) + 10.0)
+
+
+def schaffer_f7(x: jax.Array) -> jax.Array:
+    """Schaffer's F7 kernel. Minimum 0 at origin. Needs ``ndim >= 2``.
+
+    ``((1/(D-1)) * sum(sqrt(s_i) * (1 + sin^2(50 * s_i^0.2))))^2``
+    with ``s_i = sqrt(x_i^2 + x_{i+1}^2)``. The epsilon inside the
+    square roots keeps the gradient finite at the origin while
+    letting NaN inputs propagate (unlike ``sj.sqrt``).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``, ``ndim >= 2``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    ndim = x.shape[-1]
+    s = jnp.sqrt(x[:-1] ** 2 + x[1:] ** 2 + 1e-12)
+    terms = jnp.sqrt(s) * (1.0 + jnp.sin(50.0 * s**0.2) ** 2)
+    return (jnp.sum(terms) / (ndim - 1)) ** 2
+
+
+def levy(x: jax.Array) -> jax.Array:
+    """Levy kernel. Minimum 0 at ``x = 1`` (all-ones), NOT the origin.
+
+    ``w = 1 + (x - 1)/4``; the CEC 2017 reference code applies no
+    shrink, so the shifted suite function's argmin is displaced
+    from the shift vector by the rotated all-ones point (handled
+    by the ``x_opt_from`` resolver in ``spec.py``).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    w = 1.0 + (x - 1.0) / 4.0
+    term1 = jnp.sin(jnp.pi * w[0]) ** 2
+    middle = jnp.sum(
+        (w[:-1] - 1.0) ** 2
+        * (1.0 + 10.0 * jnp.sin(jnp.pi * w[:-1] + 1.0) ** 2)
+    )
+    term3 = (w[-1] - 1.0) ** 2 * (1.0 + jnp.sin(2.0 * jnp.pi * w[-1]) ** 2)
+    return term1 + middle + term3
+
+
+def modified_schwefel(x: jax.Array) -> jax.Array:
+    """Modified Schwefel kernel. Minimum 0 at origin.
+
+    Ported branch-for-branch from ``schwefel_func`` in the
+    reference code: ``z = x + 420.9687...``, three regimes
+    (``|z| <= 500``, ``z > 500``, ``z < -500``) with an
+    out-of-range quadratic penalty scaled by ``1/(10000 D)``.
+    All branches are evaluated everywhere and selected with
+    ``jnp.where``; their values and gradients are finite for
+    finite inputs (epsilon-guarded square roots), so the
+    unselected branches contribute exact zeros to the gradient
+    and NaN inputs propagate through the selected branch.
+
+    Note
+    ----
+    The reference code's zero-offset literal ``418.98288...``
+    is replaced by evaluating the mid branch at the shift
+    constant in the input's dtype (the literal is exactly that
+    value in float64), so cancellation at the optimum is exact
+    at whichever precision JAX is configured for — the same
+    treatment as ``schwefel_xsinx`` in ``bbob.py``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    ndim = x.shape[-1]
+
+    def mid(z: jax.Array) -> jax.Array:
+        return z * jnp.sin(jnp.sqrt(jnp.abs(z) + 1e-12))
+
+    z = x + 4.209687462275036e2
+    penalty_scale = 1.0 / (10000.0 * ndim)
+
+    g_mid = mid(z)
+    high_arg = 500.0 - jnp.mod(z, 500.0)
+    g_high = (
+        high_arg * jnp.sin(jnp.sqrt(high_arg + 1e-12))
+        - (z - 500.0) ** 2 * penalty_scale
+    )
+    low_arg = 500.0 - jnp.mod(jnp.abs(z), 500.0)
+    g_low = (
+        -low_arg * jnp.sin(jnp.sqrt(low_arg + 1e-12))
+        - (z + 500.0) ** 2 * penalty_scale
+    )
+
+    g = jnp.where(z > 500.0, g_high, jnp.where(z < -500.0, g_low, g_mid))
+    g_ref = mid(jnp.asarray(4.209687462275036e2, dtype=x.dtype))
+    return g_ref * ndim - jnp.sum(g)
 
 
 def hybrid_composition(

--- a/src/bbob_jax/_src/factories.py
+++ b/src/bbob_jax/_src/factories.py
@@ -408,6 +408,62 @@ def make_cec2005(
     return Partial(fn, x_opt=x_opt, f_opt=f_opt_val, R=R, Q=Q), f_opt_val
 
 
+def make_cec2017(
+    fn: Callable,
+    ndim: int,
+    key: PRNGKeyArray | None = None,
+    min_ndim: int = 1,
+    deterministic: bool = False,
+) -> BBOBFn:
+    """Factory for CEC 2017 functions with seed-generated params.
+
+    Delegates to :func:`make_cec2005` (same sampling scheme:
+    distinct subkeys for R, Q, x_opt and f_opt) with the shift
+    sampled in ``[-80, 80]^D`` as in the official suite, where
+    shifts stay inside 80% of the ``[-100, 100]`` search range.
+
+    Parameters
+    ----------
+    fn : Callable
+        Base CEC 2017 function.
+    ndim : int
+        Number of input dimensions.
+    key : PRNGKeyArray or None, optional
+        JAX random key. Required when ``deterministic`` is
+        False; ignored otherwise.
+    min_ndim : int, optional
+        Smallest ``ndim`` the function is defined for
+        (default 1).
+    deterministic : bool, optional
+        When True, use zero shift, identity rotations and zero
+        ``f_opt`` instead of sampling from ``key``.
+
+    Returns
+    -------
+    BBOBFn
+        Tuple of (partial function, optimal value).
+
+    Raises
+    ------
+    ValueError
+        If ``ndim < min_ndim``.
+    """
+    if ndim < min_ndim:
+        raise ValueError(
+            f"{getattr(fn, '__name__', fn)} requires ndim >= {min_ndim}, "
+            f"got {ndim}"
+        )
+    return make_cec2005(
+        fn,
+        ndim,
+        key,
+        num_components=1,
+        minval=-80.0,
+        maxval=80.0,
+        deterministic=deterministic,
+    )
+
+
 def make_cec2005_conditioned(
     fn: Callable,
     ndim: int,

--- a/src/bbob_jax/_src/problem.py
+++ b/src/bbob_jax/_src/problem.py
@@ -57,6 +57,9 @@ class Problem(NamedTuple):
         Function characteristics (suite-specific schema).
     noisy : bool
         Whether ``fn`` takes a PRNG key as second argument.
+    min_ndim : int
+        Smallest ``ndim`` the function is defined for;
+        construction raises ``ValueError`` below it.
     """
 
     name: str
@@ -66,6 +69,7 @@ class Problem(NamedTuple):
     bounds: tuple[float, float]
     tags: dict[str, bool]
     noisy: bool
+    min_ndim: int
 
 
 def problem(
@@ -118,4 +122,5 @@ def problem(
         bounds=spec.bounds,
         tags=dict(spec.tags),
         noisy=spec.tags.get("noise", False),
+        min_ndim=spec.min_ndim,
     )

--- a/src/bbob_jax/_src/registry.py
+++ b/src/bbob_jax/_src/registry.py
@@ -1,6 +1,6 @@
-"""Registries for the BBOB and CEC 2005 benchmark functions.
+"""Registries for the BBOB, CEC 2005 and CEC 2017 benchmark functions.
 
-The four registry dicts are derived views of the
+The six registry dicts are derived views of the
 :class:`~bbob_jax._src.spec.FunctionSpec` table in ``spec.py``:
 the randomized registries call each spec's maker as-is, the
 ``*_original`` registries bind ``deterministic=True`` (zero
@@ -25,7 +25,7 @@ from jaxtyping import PRNGKeyArray
 
 # Local
 from bbob_jax._src.factories import BBOBFn
-from bbob_jax._src.spec import BBOB_SPECS, CEC2005_SPECS
+from bbob_jax._src.spec import BBOB_SPECS, CEC2005_SPECS, CEC2017_SPECS
 
 #                                                          Authorship & Credits
 # =============================================================================
@@ -48,4 +48,12 @@ cec2005_registry: dict[str, Callable] = {
 
 cec2005_registry_original: dict[str, Callable] = {
     s.name: Partial(s.maker, deterministic=True) for s in CEC2005_SPECS
+}
+
+cec2017_registry: dict[str, Callable] = {
+    s.name: s.maker for s in CEC2017_SPECS
+}
+
+cec2017_registry_original: dict[str, Callable] = {
+    s.name: Partial(s.maker, deterministic=True) for s in CEC2017_SPECS
 }

--- a/src/bbob_jax/_src/spec.py
+++ b/src/bbob_jax/_src/spec.py
@@ -5,9 +5,10 @@ knows about one function: its implementation, the factory that
 constructs problem instances (randomized or deterministic),
 its metadata tags, its search-space bounds and where its true
 optimum lives. The public registries, tag dicts and bounds
-dicts in ``registry.py``, ``tags.py``, ``cec2005_tags.py`` and
-``bounds.py`` are all derived views of this table — adding a
-function means adding its implementation and one row here.
+dicts in ``registry.py``, ``tags.py``, ``cec2005_tags.py``,
+``cec2017_tags.py`` and ``bounds.py`` are all derived views of
+this table — adding a function means adding its implementation
+and one row here.
 """
 
 #                                                                       Modules
@@ -22,6 +23,8 @@ from typing import Any, NamedTuple, cast
 import jax
 import jax.numpy as jnp
 from jax.tree_util import Partial
+
+from bbob_jax._src import cec2017
 
 # Local
 from bbob_jax._src.bbob import (
@@ -98,6 +101,7 @@ from bbob_jax._src.factories import (
     make_bbob,
     make_cec2005,
     make_cec2005_conditioned,
+    make_cec2017,
 )
 
 #                                                          Authorship & Credits
@@ -158,6 +162,16 @@ def _griewank_rosenbrock_x_opt(kw: dict[str, Any], ndim: int) -> jax.Array:
     )
 
 
+def _cec2017_levy_x_opt(kw: dict[str, Any], ndim: int) -> jax.Array:
+    """cec2017_f9: the Levy kernel's minimum is at ``z = ones``.
+
+    ``z = R @ (x - x_opt)`` is all-ones at the minimum, so the
+    minimizer is ``x_opt + R.T @ ones`` — not the sampled shift,
+    matching the official reference code (see ``cec2017.f9``).
+    """
+    return cast(jax.Array, kw["x_opt"] + kw["R"].T @ jnp.ones(ndim))
+
+
 #                                                                  Tag schemas
 # =============================================================================
 
@@ -194,6 +208,36 @@ def _cec_tags(
     }
 
 
+def _cec2017_tags(
+    *,
+    unimodal: bool = False,
+    hybrid: bool = False,
+    composition: bool = False,
+    rotated: bool = True,
+    structure_modified: bool = False,
+) -> dict[str, bool]:
+    """CEC 2017 tag schema.
+
+    ``unimodal`` and ``multimodal`` are mutually exclusive;
+    ``hybrid`` marks F11-F20 (shuffled dimension chunks),
+    ``composition`` marks F21-F30; both imply multimodal.
+    There is no ``noise`` key — the suite has no stochastic
+    functions. ``rotated`` defaults to True (every function is
+    shifted and rotated except F6, whose rotation is dead code
+    in the official reference — see ``cec2017.f6``).
+    ``structure_modified`` marks deviations from the reference
+    code for JAX compatibility.
+    """
+    return {
+        "unimodal": unimodal,
+        "multimodal": not unimodal,
+        "hybrid": hybrid,
+        "composition": composition,
+        "rotated": rotated,
+        "structure_modified": structure_modified,
+    }
+
+
 #                                                                 FunctionSpec
 # =============================================================================
 
@@ -206,7 +250,8 @@ class FunctionSpec(NamedTuple):
     name : str
         Registry key of the function.
     suite : str
-        Benchmark suite, ``"bbob"`` or ``"cec2005"``.
+        Benchmark suite, ``"bbob"``, ``"cec2005"`` or
+        ``"cec2017"``.
     maker : Callable
         Factory constructing a problem instance. Called as
         ``maker(ndim=..., key=..., deterministic=...)`` and
@@ -218,6 +263,10 @@ class FunctionSpec(NamedTuple):
     x_opt_from : Callable
         Resolver mapping the constructed Partial's keyword dict
         (plus ``ndim``) to the location of the global minimum.
+    min_ndim : int
+        Smallest ``ndim`` the function is defined for. Makers
+        raise ``ValueError`` below it (e.g. CEC 2017 hybrids
+        need one dimension per subcomponent kernel).
     """
 
     name: str
@@ -226,6 +275,7 @@ class FunctionSpec(NamedTuple):
     tags: dict[str, bool]
     bounds: tuple[float, float]
     x_opt_from: Callable[[dict[str, Any], int], jax.Array] = _default_x_opt
+    min_ndim: int = 1
 
 
 #                                                                   BBOB table
@@ -877,10 +927,89 @@ CEC2005_SPECS: tuple[FunctionSpec, ...] = (
 )
 
 
+#                                                               CEC 2017 table
+# =============================================================================
+# F1-F10 (simple functions); the hybrids F11-F20 and compositions F21-F30
+# follow in later waves. F2 was officially withdrawn and is not implemented;
+# the numbering keeps the hole, matching the reference code and data files.
+
+CEC2017_BOUNDS: tuple[float, float] = (-100.0, 100.0)
+
+CEC2017_SPECS: tuple[FunctionSpec, ...] = (
+    FunctionSpec(
+        name="cec2017_f1",
+        suite="cec2017",
+        maker=Partial(make_cec2017, fn=cec2017.f1),
+        tags=_cec2017_tags(unimodal=True),
+        bounds=CEC2017_BOUNDS,
+    ),
+    FunctionSpec(
+        name="cec2017_f3",
+        suite="cec2017",
+        maker=Partial(make_cec2017, fn=cec2017.f3),
+        tags=_cec2017_tags(unimodal=True),
+        bounds=CEC2017_BOUNDS,
+    ),
+    FunctionSpec(
+        name="cec2017_f4",
+        suite="cec2017",
+        maker=Partial(make_cec2017, fn=cec2017.f4),
+        tags=_cec2017_tags(),
+        bounds=CEC2017_BOUNDS,
+    ),
+    FunctionSpec(
+        name="cec2017_f5",
+        suite="cec2017",
+        maker=Partial(make_cec2017, fn=cec2017.f5),
+        tags=_cec2017_tags(),
+        bounds=CEC2017_BOUNDS,
+    ),
+    FunctionSpec(
+        name="cec2017_f6",
+        suite="cec2017",
+        # Rotation is dead code in the official reference (see cec2017.f6),
+        # so the instance is shift-only: rotated=False.
+        maker=Partial(make_cec2017, fn=cec2017.f6, min_ndim=2),
+        tags=_cec2017_tags(rotated=False),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=2,
+    ),
+    FunctionSpec(
+        name="cec2017_f7",
+        suite="cec2017",
+        maker=Partial(make_cec2017, fn=cec2017.f7),
+        tags=_cec2017_tags(),
+        bounds=CEC2017_BOUNDS,
+    ),
+    FunctionSpec(
+        name="cec2017_f8",
+        suite="cec2017",
+        maker=Partial(make_cec2017, fn=cec2017.f8),
+        tags=_cec2017_tags(),
+        bounds=CEC2017_BOUNDS,
+    ),
+    FunctionSpec(
+        name="cec2017_f9",
+        suite="cec2017",
+        maker=Partial(make_cec2017, fn=cec2017.f9),
+        tags=_cec2017_tags(),
+        bounds=CEC2017_BOUNDS,
+        x_opt_from=_cec2017_levy_x_opt,
+    ),
+    FunctionSpec(
+        name="cec2017_f10",
+        suite="cec2017",
+        maker=Partial(make_cec2017, fn=cec2017.f10),
+        tags=_cec2017_tags(),
+        bounds=CEC2017_BOUNDS,
+    ),
+)
+
+
 #                                                                Derived views
 # =============================================================================
 
-SPECS: tuple[FunctionSpec, ...] = BBOB_SPECS + CEC2005_SPECS
+SPECS: tuple[FunctionSpec, ...] = BBOB_SPECS + CEC2005_SPECS + CEC2017_SPECS
 SPEC_BY_NAME: dict[str, FunctionSpec] = {s.name: s for s in SPECS}
 
 if len(SPEC_BY_NAME) != len(SPECS):

--- a/src/bbob_jax/bounds.py
+++ b/src/bbob_jax/bounds.py
@@ -1,3 +1,3 @@
-from ._src.bounds import bbob_bounds, cec2005_bounds
+from ._src.bounds import bbob_bounds, cec2005_bounds, cec2017_bounds
 
-__all__ = ["bbob_bounds", "cec2005_bounds"]
+__all__ = ["bbob_bounds", "cec2005_bounds", "cec2017_bounds"]

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -2,7 +2,7 @@ import math
 
 import pytest
 
-from bbob_jax import bbob_bounds, cec2005_bounds, registry
+from bbob_jax import bbob_bounds, cec2005_bounds, cec2017_bounds, registry
 from bbob_jax._src.bounds import BBOB_BOUNDS
 
 
@@ -33,6 +33,22 @@ def test_bounds_count():
 def test_no_key_overlap():
     """BBOB and CEC 2005 function names do not overlap."""
     assert set(bbob_bounds.keys()).isdisjoint(set(cec2005_bounds.keys()))
+
+
+def test_cec2017_bounds_keys():
+    """cec2017_bounds covers F1 and F3-F10 (F2 was withdrawn); the
+    hybrid and composition waves extend this set."""
+    assert set(cec2017_bounds.keys()) == {
+        f"cec2017_f{i}" for i in range(1, 11) if i != 2
+    }
+
+
+def test_cec2017_bounds_values():
+    """All CEC 2017 bounds are (-100.0, 100.0)."""
+    for name, bounds in cec2017_bounds.items():
+        assert bounds == (-100.0, 100.0), (
+            f"{name}: expected (-100.0, 100.0), got {bounds}"
+        )
 
 
 def test_constants():

--- a/tests/test_cec2017.py
+++ b/tests/test_cec2017.py
@@ -1,0 +1,142 @@
+"""Tests for CEC 2017 benchmark functions (F1, F3-F10).
+
+These tests validate JAX compatibility (jit, vmap, grad), NaN propagation
+and basic sanity checks. They do NOT validate that results match the
+official CEC 2017 data files — instances are seed-generated (see the
+``cec2017`` module docstring); a cross-validation script against the
+official reference data accompanies the composition wave.
+"""
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from bbob_jax import cec2017_registry, cec2017_registry_original
+from bbob_jax._src.mesh import _create_mesh
+
+pytest_cec2017 = [
+    pytest.param(name, fn, id=f"cec2017_registry::{name}")
+    for name, fn in cec2017_registry.items()
+]
+pytest_cec2017_original = [
+    pytest.param(name, fn, id=f"cec2017_registry_original::{name}")
+    for name, fn in cec2017_registry_original.items()
+]
+all_cec2017 = pytest_cec2017 + pytest_cec2017_original
+
+dimensions = [2, 3, 5, 10, 20]
+
+
+@pytest.mark.parametrize("name,fn", all_cec2017)
+@pytest.mark.parametrize("dim", dimensions)
+def test_function_output(name, fn, dim):
+    key = jr.key(0)
+    x = jr.uniform(key, shape=(dim,), minval=-100.0, maxval=100.0)
+    fn_func, _ = fn(ndim=dim, key=key)
+    y = fn_func(x)
+    assert jnp.isfinite(y), f"{name} returned non-finite value: {y}"
+    assert jnp.ndim(y) == 0, f"{name} did not return scalar: {y.shape}"
+
+
+@pytest.mark.parametrize("name,fn", all_cec2017)
+@pytest.mark.parametrize("dim", dimensions)
+def test_function_output_jit(name, fn, dim):
+    key = jr.key(0)
+    x = jr.uniform(key, shape=(dim,), minval=-100.0, maxval=100.0)
+    fn_func, _ = fn(ndim=dim, key=key)
+    y = jax.jit(fn_func)(x)
+    assert jnp.isfinite(y), f"{name} JIT returned non-finite: {y}"
+    assert jnp.ndim(y) == 0
+
+
+@pytest.mark.parametrize("name,fn", all_cec2017)
+@pytest.mark.parametrize("dim", dimensions)
+def test_function_nan_propagates(name, fn, dim):
+    """NaN inputs must propagate to the output, not be silently masked.
+
+    Same guarantee as the BBOB suite (see test_example.py): a function
+    that returns a finite value for a NaN input hides invalid inputs
+    from the caller. This is why the CEC 2017 kernels use
+    epsilon-guarded ``jnp.sqrt`` instead of ``sj.sqrt`` (which maps
+    NaN to 0).
+    """
+    key = jr.key(0)
+    fn_func, _ = fn(ndim=dim, key=key)
+
+    x_all_nan = jnp.full((dim,), jnp.nan)
+    assert jnp.isnan(fn_func(x_all_nan)), (
+        f"Function {name} did not propagate an all-NaN input."
+    )
+
+    x_partial_nan = jnp.zeros((dim,)).at[0].set(jnp.nan)
+    assert jnp.isnan(fn_func(x_partial_nan)), (
+        f"Function {name} did not propagate a single-coordinate NaN input."
+    )
+
+    x_last_nan = jnp.zeros((dim,)).at[-1].set(jnp.nan)
+    assert jnp.isnan(fn_func(x_last_nan)), (
+        f"Function {name} did not propagate a last-coordinate NaN input."
+    )
+
+
+@pytest.mark.parametrize("name,fn", pytest_cec2017)
+@pytest.mark.parametrize("dim", [2])
+@pytest.mark.parametrize("seed", [1, 2])
+def test_function_vmap(name, fn, dim, seed):
+    key = jr.key(seed)
+    fn_func, _ = fn(ndim=dim, key=key)
+    _, _, Z = _create_mesh(fn_func, bounds=(-100.0, 100.0), px=50)
+    assert jnp.all(jnp.isfinite(Z)), f"{name} vmap returned non-finite values"
+
+
+@pytest.mark.parametrize("name,fn", pytest_cec2017)
+@pytest.mark.parametrize("dim", dimensions)
+@pytest.mark.parametrize("seed", [1, 2])
+def test_function_grad(name, fn, dim, seed):
+    key = jr.key(seed)
+    key_x, key_fn = jr.split(key)
+    x = jr.uniform(key_x, shape=(10, dim), minval=-100.0, maxval=100.0)
+    fn_func, _ = fn(ndim=dim, key=key_fn)
+    grad_value = jax.vmap(jax.grad(fn_func))(x)
+    assert grad_value.shape == x.shape
+    assert jnp.all(jnp.isfinite(grad_value)), (
+        f"{name} grad returned non-finite"
+    )
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        pytest.param(cec2017_registry["cec2017_f6"], id="randomized"),
+        pytest.param(cec2017_registry_original["cec2017_f6"], id="original"),
+    ],
+)
+def test_f6_min_ndim_raises(fn):
+    """Schaffer F7's ``1/(D-1)^2`` normalization is undefined at D=1."""
+    with pytest.raises(ValueError, match="ndim >= 2"):
+        fn(ndim=1, key=jr.key(0))
+
+
+@pytest.mark.parametrize("dim", [3, 10])
+def test_f5_f8_same_structure_different_instance(dim):
+    """F8's non-continuity transform is dead code in the reference,
+    so F5 and F8 share their math but not their sampled instance."""
+    key = jr.key(7)
+    f5_fn, _ = cec2017_registry["cec2017_f5"](ndim=dim, key=key)
+    f8_fn, _ = cec2017_registry["cec2017_f8"](ndim=dim, key=key)
+    x = jr.uniform(jr.key(8), shape=(dim,), minval=-100.0, maxval=100.0)
+    # Identical math with identical parameters (same key, same maker) ...
+    assert jnp.array_equal(f5_fn(x), f8_fn(x))
+    # ... but downstream instances use per-function keys, and the
+    # deterministic instances coincide by construction.
+    f5_det, _ = cec2017_registry_original["cec2017_f5"](ndim=dim)
+    f8_det, _ = cec2017_registry_original["cec2017_f8"](ndim=dim)
+    assert jnp.array_equal(f5_det(x), f8_det(x))
+
+
+@pytest.mark.parametrize("name,fn", pytest_cec2017_original)
+def test_deterministic_needs_no_key(name, fn):
+    fn_func, f_opt = fn(ndim=3)
+    assert jnp.isfinite(fn_func(jnp.ones(3)))
+    assert f_opt == 0.0

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -14,6 +14,10 @@ from bbob_jax import (
     cec2005_function_characteristics,
     cec2005_registry,
     cec2005_registry_original,
+    cec2017_bounds,
+    cec2017_function_characteristics,
+    cec2017_registry,
+    cec2017_registry_original,
     function_characteristics,
     registry,
     registry_original,
@@ -26,6 +30,14 @@ CEC_TAG_KEYS = {
     "composition",
     "rotated",
     "noise",
+    "structure_modified",
+}
+CEC2017_TAG_KEYS = {
+    "unimodal",
+    "multimodal",
+    "hybrid",
+    "composition",
+    "rotated",
     "structure_modified",
 }
 
@@ -44,12 +56,26 @@ def test_cec2005_key_sets_are_identical():
     assert set(cec2005_bounds.keys()) == names
 
 
+def test_cec2017_key_sets_are_identical():
+    names = set(cec2017_registry.keys())
+    assert set(cec2017_registry_original.keys()) == names
+    assert set(cec2017_function_characteristics.keys()) == names
+    assert set(cec2017_bounds.keys()) == names
+
+
 def test_suites_do_not_overlap():
     assert set(registry.keys()).isdisjoint(cec2005_registry.keys())
+    assert set(registry.keys()).isdisjoint(cec2017_registry.keys())
+    assert set(cec2005_registry.keys()).isdisjoint(cec2017_registry.keys())
 
 
 @pytest.mark.parametrize(
-    "tags_dict", [function_characteristics, cec2005_function_characteristics]
+    "tags_dict",
+    [
+        function_characteristics,
+        cec2005_function_characteristics,
+        cec2017_function_characteristics,
+    ],
 )
 def test_unknown_name_raises_key_error(tags_dict):
     """Plain dicts: a typo raises instead of returning {}."""
@@ -75,3 +101,37 @@ def test_rastrigin_variants_are_multimodal():
     """Regression pin: these were mislabeled unimodal before the spec."""
     assert not function_characteristics["rastrigin_seperable"]["unimodal"]
     assert not function_characteristics["skew_rastrigin_bueche"]["unimodal"]
+
+
+def test_cec2017_tag_schema():
+    for name, tags in cec2017_function_characteristics.items():
+        assert set(tags.keys()) == CEC2017_TAG_KEYS, name
+        assert tags["multimodal"] == (not tags["unimodal"]), name
+        if tags["hybrid"] or tags["composition"]:
+            assert tags["multimodal"], name
+        assert not (tags["hybrid"] and tags["composition"]), name
+
+
+def test_cec2017_unimodal_set():
+    """Only F1 (Bent Cigar) and F3 (Zakharov) are unimodal."""
+    unimodal = {
+        name
+        for name, tags in cec2017_function_characteristics.items()
+        if tags["unimodal"]
+    }
+    assert unimodal == {"cec2017_f1", "cec2017_f3"}
+
+
+def test_cec2017_f6_is_not_rotated():
+    """Regression pin: the reference code never applies F6's rotation
+    (the kernel reads the pre-rotation shift buffer), so the instance
+    is shift-only."""
+    assert not cec2017_function_characteristics["cec2017_f6"]["rotated"]
+    rotated_rest = {
+        name
+        for name, tags in cec2017_function_characteristics.items()
+        if tags["rotated"]
+    }
+    assert rotated_rest == set(cec2017_function_characteristics) - {
+        "cec2017_f6"
+    }

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -18,6 +18,9 @@ from bbob_jax import (
     cec2005_bounds,
     cec2005_function_characteristics,
     cec2005_registry,
+    cec2017_bounds,
+    cec2017_function_characteristics,
+    cec2017_registry,
     function_characteristics,
     problem,
     registry,
@@ -25,6 +28,7 @@ from bbob_jax import (
 
 BBOB_NAMES = list(registry.keys())
 CEC_NAMES = list(cec2005_registry.keys())
+CEC2017_NAMES = list(cec2017_registry.keys())
 COMPOSITION_NAMES = [f"f{i}" for i in range(15, 26)]
 
 _NOISY = {
@@ -61,7 +65,7 @@ def test_missing_key_raises():
         problem("sphere", ndim=2)
 
 
-@pytest.mark.parametrize("name", BBOB_NAMES + CEC_NAMES)
+@pytest.mark.parametrize("name", BBOB_NAMES + CEC_NAMES + CEC2017_NAMES)
 def test_problem_fields_match_metadata_dicts(name):
     """Problem bundles the same facts the separate dicts expose."""
     p = problem(name, ndim=3, key=jr.key(0))
@@ -69,10 +73,15 @@ def test_problem_fields_match_metadata_dicts(name):
         assert p.bounds == bbob_bounds[name]
         assert p.tags == function_characteristics[name]
         assert p.noisy is False
-    else:
+    elif name in CEC_NAMES:
         assert p.bounds == cec2005_bounds[name]
         assert p.tags == cec2005_function_characteristics[name]
         assert p.noisy == cec2005_function_characteristics[name]["noise"]
+    else:
+        assert p.bounds == cec2017_bounds[name]
+        assert p.tags == cec2017_function_characteristics[name]
+        assert p.noisy is False
+        assert p.min_ndim >= 1
 
 
 @pytest.mark.parametrize("name", BBOB_NAMES)
@@ -159,3 +168,29 @@ def test_noisy_problems_take_key(name):
     assert p.noisy
     value = p.fn(jnp.zeros(3), jr.key(1))
     assert jnp.isfinite(value)
+
+
+@pytest.mark.parametrize("name", CEC2017_NAMES)
+@pytest.mark.parametrize("dim", [2, 5, 10])
+@pytest.mark.parametrize("deterministic", [False, True])
+def test_cec2017_global_minimum_at_x_opt(name, dim, deterministic):
+    """fn(x_opt) == f_opt for every CEC 2017 function, both modes.
+
+    The 1e-5 tolerance covers the epsilon guards inside the kernels'
+    square roots (F6's Schaffer F7 floor is ~1e-6); for ``cec2017_f9``
+    the resolver places x_opt at the rotated all-ones point, so this
+    also pins the Levy optimum-displacement handling.
+    """
+    p = problem(name, ndim=dim, key=jr.key(0), deterministic=deterministic)
+    result = p.fn(p.x_opt)
+    assert jnp.isclose(result, p.f_opt, atol=1e-5), (
+        f"{name} dim={dim} deterministic={deterministic}: "
+        f"fn(x_opt)={result}, f_opt={p.f_opt}, diff={result - p.f_opt}"
+    )
+
+
+def test_cec2017_min_ndim_surfaces_in_problem():
+    p = problem("cec2017_f6", ndim=2, key=jr.key(0))
+    assert p.min_ndim == 2
+    with pytest.raises(ValueError, match="ndim >= 2"):
+        problem("cec2017_f6", ndim=1, key=jr.key(0))


### PR DESCRIPTION
## CEC 2017 wave 1/3: simple functions F1, F3–F10

First of three PRs adding the CEC 2017 bound-constrained suite (Awad et al., 2016). This wave lands the nine simple functions plus the plumbing the later waves build on; wave 2 adds the hybrids F11–F20, wave 3 the compositions F21–F30 + official-data cross-check script + docs/plots.

### Ground truth

Implemented against the official reference `cec17_test_func.c` with the report as secondary source — **code wins** where they disagree, and every divergence is documented in the function docstring:

- **F2 is excluded** (officially withdrawn; overflow at high D). Numbering keeps the hole (`cec2017_f1`, `cec2017_f3`…), matching the reference code and data files — the "final version updated" report renumbers 1–29 instead; we do not follow that.
- **F6**: the report says Schaffer F7 with `0.5/100` shrink and rotation; in the code the kernel reads the pre-rotation shift buffer with shrink 1.0 — the rotation is dead code. Implemented shift-only (`rotated=False` tag).
- **F8**: the report's non-continuity transform (and tosz/tasy) is dead code in the reference — the function actually computed is plain shifted-rotated Rastrigin (F5's structure with its own instance).
- **F9 (Levy)**: no shrink (report says `5.12/100`), and the kernel's minimum is at all-ones, so the true argmin is `x_opt + R.T @ ones`, not the sampled shift — same as the official suite, where `F9(o_9) != 900`. Handled via a spec-table `x_opt_from` resolver (existing `rosenbrock_rotated` precedent), so `fn(x_opt) == f_opt` holds.
- **F7 (Lunacek)**: single `10/100` scale per the code (the report's eq. 25 double-counts), sign flip keyed to the shift vector's sign (static per instance), rotation applied to the cosine term only.

### Conventions

- Instances are **seed-generated** (shift in `[-80, 80]^D` as official, random rotation, sampled `f_opt`), `deterministic=True` = zero shift / identity rotation / zero `f_opt` — same contract as the other suites. Results will not match published CEC 2017 tables (module docstring says so).
- New **`min_ndim`** field on `FunctionSpec` and `Problem` (default 1): `cec2017_f6` needs `ndim >= 2` (`1/(D−1)²` normalization); hybrids in wave 2 will need one dimension per subcomponent. Makers raise `ValueError` below it.
- **No softjax needed** in this wave: F8's rounding is dead code, F7's sign flip is static, and all square roots use the epsilon-guard idiom from `composition.py` — deliberately, because `sj.sqrt` maps NaN to 0 and would break NaN propagation.
- **NaN in → NaN out** is now a tested guarantee for the suite (all-NaN, first- and last-coordinate NaN), same as BBOB.
- `modified_schwefel`'s zero-offset constant is computed at runtime dtype instead of the reference's float64 literal (same treatment as `schwefel_xsinx`), giving exact cancellation at the optimum under both x32 and x64.

### Structure

- Kernels (`cec_bent_cigar`, `zakharov`, `cec_rosenbrock`, `cec_rastrigin`, `schaffer_f7`, `levy`, `modified_schwefel`) live in `composition.py` for reuse by the hybrid/composition waves; `cec2017.py` holds the function definitions with the standard `fn(x, x_opt, f_opt, R, Q)` signature.
- Tag schema: `{unimodal, multimodal, hybrid, composition, rotated, structure_modified}` — no `noise` key (no stochastic functions in this suite).
- Derived views follow the spec-table pattern: `cec2017_registry(_original)`, `cec2017_function_characteristics`, `cec2017_bounds` (all `(-100, 100)`).

### Tests

New `test_cec2017.py` battery (scalar/jit/vmap/grad/NaN over dims 2–20 × both registries × seeds), plus `min_ndim` raise tests, an F5≡F8 structure pin, and extensions to `test_consistency.py` (schema, unimodal set = {f1, f3}, F6 not-rotated pin), `test_problem.py` (`fn(x_opt) == f_opt` both modes, metadata match, `min_ndim` surfacing) and `test_bounds.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
