### PR TITLE
CEC 2017 wave 2/3: hybrid functions F11–F20

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`bbob-jax` is a JAX implementation of the 24 BBOB (Black-Box Optimization Benchmark) noise-free functions, the 25 CEC 2005 benchmark functions, and the CEC 2017 bound-constrained suite (in progress: F1, F3–F10 landed; hybrids F11–F20 and compositions F21–F30 follow; F2 was officially withdrawn and is skipped). The key value-add over the original C implementations is full JAX compatibility: automatic differentiation, JIT compilation, and vectorization via `vmap`.
+`bbob-jax` is a JAX implementation of the 24 BBOB (Black-Box Optimization Benchmark) noise-free functions, the 25 CEC 2005 benchmark functions, and the CEC 2017 bound-constrained suite (in progress: F1, F3–F20 landed; compositions F21–F30 follow; F2 was officially withdrawn and is skipped). The key value-add over the original C implementations is full JAX compatibility: automatic differentiation, JIT compilation, and vectorization via `vmap`.
 
 ## Commands
 
@@ -68,8 +68,9 @@ p.fn, p.x_opt, p.f_opt, p.bounds, p.tags, p.noisy
 deterministic CEC compositions are degenerate). Noisy CEC functions
 (`noise` tag) are called as `fn(x, key)`. `Problem.min_ndim` is the
 smallest supported dimension (default 1); makers raise `ValueError` below
-it (e.g. `cec2017_f6` needs `ndim >= 2`, CEC 2017 hybrids will need one
-dimension per subcomponent kernel).
+it (e.g. `cec2017_f6` needs `ndim >= 2`; CEC 2017 hybrids need one
+dimension per subcomponent kernel and up to 7 where the chunk split
+demands it — see `cec2017_hybrid_partition`).
 
 ### Core Function Signature
 

--- a/src/bbob_jax/_src/cec2017.py
+++ b/src/bbob_jax/_src/cec2017.py
@@ -30,9 +30,18 @@ import jax
 import jax.numpy as jnp
 
 from bbob_jax._src.composition import (
+    ackley,
+    cec2005_weierstrass,
+    cec2017_hybrid_partition,
+    cec2017_katsuura,
     cec_bent_cigar,
     cec_rastrigin,
     cec_rosenbrock,
+    discus,
+    expanded_griewank_rosenbrock,
+    expanded_schaffer_f6,
+    hgbat,
+    high_conditioned_elliptic,
     levy,
     modified_schwefel,
     schaffer_f7,
@@ -391,3 +400,537 @@ def f10(
     """
     z = R @ (10.0 * (x - x_opt))
     return modified_schwefel(z) + f_opt
+
+
+#                                                     Hybrid functions F11-F20
+# =============================================================================
+# Shared structure (hf01-hf10 in the reference code): the whole input is
+# shifted, rotated and then SHUFFLED (``y = (R @ (x - x_opt))[shuffle]``),
+# split into contiguous chunks by the official proportions, and each chunk
+# is fed to one kernel with a kernel-specific shrink rate. Chunk sizes come
+# from :func:`cec2017_hybrid_partition` (the reference ceil rule wherever it
+# is well-defined). The trailing ``0.0 * jnp.sum(y)`` term is an exact zero
+# for finite inputs and exists solely to propagate NaN through coordinates
+# a hybrid ignores (single-coordinate Rosenbrock chunks have an empty sum;
+# the Schaffer F7 sub-kernel reads the wrong coordinates entirely — see
+# ``f14``/``f20``).
+
+
+def _hybrid_chunks(
+    y: jax.Array,
+    proportions: tuple[float, ...],
+    min_sizes: tuple[int, ...],
+) -> list[jax.Array]:
+    """Split the shuffled vector into per-kernel chunks."""
+    sizes = cec2017_hybrid_partition(y.shape[-1], proportions, min_sizes)
+    chunks = []
+    start = 0
+    for size in sizes:
+        chunks.append(y[start : start + size])
+        start += size
+    return chunks
+
+
+def _hybrid_lunacek(chunk: jax.Array, shift_prefix: jax.Array) -> jax.Array:
+    """Lunacek Bi-Rastrigin as a hybrid sub-kernel (``bi_rastrigin_func``
+    with ``s_flag = r_flag = 0``).
+
+    The sign flip reads the LEADING entries of the hybrid's full,
+    unshuffled shift vector — not the shift belonging to this chunk's
+    coordinates. That is what the reference code's global-buffer
+    aliasing computes, and what all published results used; replicated
+    faithfully. No rotation is applied to the cosine term.
+
+    Needs a chunk of at least two dimensions: at one dimension the
+    depth factor ``s = 1 - 1/(2 sqrt(D+20) - 8.2)`` turns negative
+    and ``mu1`` is the square root of a negative number (NaN in the
+    reference code as well).
+    """
+    ndim = chunk.shape[-1]
+    mu0 = 2.5
+    d = 1.0
+    s = 1.0 - 1.0 / (2.0 * math.sqrt(ndim + 20.0) - 8.2)
+    mu1 = -math.sqrt((mu0**2 - d) / s)
+
+    y = (10.0 / 100.0) * chunk
+    flip = jnp.where(shift_prefix < 0.0, -1.0, 1.0)
+    t = 2.0 * flip * y
+    funnel0 = jnp.sum(t**2)
+    funnel1 = d * ndim + s * jnp.sum((t + (mu0 - mu1)) ** 2)
+    cos_term = 10.0 * (ndim - jnp.sum(jnp.cos(2.0 * jnp.pi * t)))
+    return jnp.minimum(funnel0, funnel1) + cos_term
+
+
+def f11(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 1 (F11): Zakharov, Rosenbrock, Rastrigin.
+
+    Proportions (0.2, 0.4, 0.4); needs ``ndim >= 3``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3 = _hybrid_chunks(y, (0.2, 0.4, 0.4), (1, 1, 1))
+    return (
+        zakharov(c1)
+        + cec_rosenbrock((2.048 / 100.0) * c2)
+        + cec_rastrigin((5.12 / 100.0) * c3)
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f12(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 2 (F12): Elliptic, Modified Schwefel, Bent Cigar.
+
+    Proportions (0.3, 0.3, 0.4); needs ``ndim >= 3``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3 = _hybrid_chunks(y, (0.3, 0.3, 0.4), (1, 1, 1))
+    return (
+        high_conditioned_elliptic(c1)
+        + modified_schwefel(10.0 * c2)
+        + cec_bent_cigar(c3)
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f13(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 3 (F13): Bent Cigar, Rosenbrock, Lunacek
+    Bi-Rastrigin.
+
+    Proportions (0.3, 0.3, 0.4); needs ``ndim >= 4`` (the Lunacek
+    chunk must hold at least two dimensions — see
+    ``_hybrid_lunacek``). The Lunacek sub-kernel's sign flip reads
+    the leading entries of the full shift vector (reference-code
+    global-buffer aliasing).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3 = _hybrid_chunks(y, (0.3, 0.3, 0.4), (1, 1, 2))
+    return (
+        cec_bent_cigar(c1)
+        + cec_rosenbrock((2.048 / 100.0) * c2)
+        + _hybrid_lunacek(c3, x_opt[: c3.shape[-1]])
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f14(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 4 (F14): Elliptic, Ackley, Schaffer F7,
+    Rastrigin.
+
+    Proportions (0.2, 0.2, 0.2, 0.4); needs ``ndim >= 6`` (the
+    Schaffer F7 chunk must hold at least two dimensions). In the
+    reference code the Schaffer F7 sub-kernel reads the LEADING
+    entries of the shuffled vector instead of its own chunk (stale
+    global-buffer aliasing) — its own chunk's coordinates never
+    influence the value. Replicated faithfully (published results
+    used it); the ``0.0 * sum(y)`` term keeps NaN propagating
+    through the ignored coordinates.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3, c4 = _hybrid_chunks(y, (0.2, 0.2, 0.2, 0.4), (1, 1, 2, 1))
+    return (
+        high_conditioned_elliptic(c1)
+        + ackley(c2)
+        + schaffer_f7(y[: c3.shape[-1]])
+        + cec_rastrigin((5.12 / 100.0) * c4)
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f15(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 5 (F15): Bent Cigar, HGBat, Rastrigin,
+    Rosenbrock.
+
+    Proportions (0.2, 0.2, 0.3, 0.3); needs ``ndim >= 4``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3, c4 = _hybrid_chunks(y, (0.2, 0.2, 0.3, 0.3), (1, 1, 1, 1))
+    return (
+        cec_bent_cigar(c1)
+        + hgbat((5.0 / 100.0) * c2)
+        + cec_rastrigin((5.12 / 100.0) * c3)
+        + cec_rosenbrock((2.048 / 100.0) * c4)
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f16(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 6 (F16): Expanded Schaffer F6, HGBat,
+    Rosenbrock, Modified Schwefel.
+
+    Proportions (0.2, 0.2, 0.3, 0.3); needs ``ndim >= 4``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3, c4 = _hybrid_chunks(y, (0.2, 0.2, 0.3, 0.3), (1, 1, 1, 1))
+    return (
+        expanded_schaffer_f6(c1)
+        + hgbat((5.0 / 100.0) * c2)
+        + cec_rosenbrock((2.048 / 100.0) * c3)
+        + modified_schwefel(10.0 * c4)
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f17(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 7 (F17): Katsuura, Ackley, Expanded
+    Griewank-Rosenbrock, Modified Schwefel, Rastrigin.
+
+    Proportions (0.1, 0.2, 0.2, 0.2, 0.3); needs ``ndim >= 5``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3, c4, c5 = _hybrid_chunks(
+        y, (0.1, 0.2, 0.2, 0.2, 0.3), (1, 1, 1, 1, 1)
+    )
+    return (
+        cec2017_katsuura((5.0 / 100.0) * c1)
+        + ackley(c2)
+        + expanded_griewank_rosenbrock((5.0 / 100.0) * c3)
+        + modified_schwefel(10.0 * c4)
+        + cec_rastrigin((5.12 / 100.0) * c5)
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f18(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 8 (F18): Elliptic, Ackley, Rastrigin, HGBat,
+    Discus.
+
+    Proportions (0.2, 0.2, 0.2, 0.2, 0.2); needs ``ndim >= 5``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3, c4, c5 = _hybrid_chunks(
+        y, (0.2, 0.2, 0.2, 0.2, 0.2), (1, 1, 1, 1, 1)
+    )
+    return (
+        high_conditioned_elliptic(c1)
+        + ackley(c2)
+        + cec_rastrigin((5.12 / 100.0) * c3)
+        + hgbat((5.0 / 100.0) * c4)
+        + discus(c5)
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f19(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 9 (F19): Bent Cigar, Rastrigin, Expanded
+    Griewank-Rosenbrock, Weierstrass, Expanded Schaffer F6.
+
+    Proportions (0.2, 0.2, 0.2, 0.2, 0.2); needs ``ndim >= 5``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3, c4, c5 = _hybrid_chunks(
+        y, (0.2, 0.2, 0.2, 0.2, 0.2), (1, 1, 1, 1, 1)
+    )
+    return (
+        cec_bent_cigar(c1)
+        + cec_rastrigin((5.12 / 100.0) * c2)
+        + expanded_griewank_rosenbrock((5.0 / 100.0) * c3)
+        + cec2005_weierstrass((0.5 / 100.0) * c4)
+        + expanded_schaffer_f6(c5)
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )
+
+
+def f20(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _shuffle: jax.Array,
+) -> jax.Array:
+    """Hybrid Function 10 (F20): HGBat, Katsuura, Ackley, Rastrigin,
+    Modified Schwefel, Schaffer F7.
+
+    Proportions (0.1, 0.1, 0.2, 0.2, 0.2, 0.2); needs ``ndim >= 7``
+    (the reference ceil split is ill-defined below ``ndim = 10``;
+    the repair split covers 7-9, keeping the Schaffer F7 chunk at
+    two dimensions). As in ``f14``, the Schaffer F7 sub-kernel reads
+    the LEADING entries of the shuffled vector instead of its own
+    chunk — reference-code global-buffer aliasing, replicated
+    faithfully.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+    _shuffle : jax.Array
+        Dimension permutation (identity when deterministic).
+
+    Returns
+    -------
+    jax.Array
+        Function value(s).
+    """
+    y = (R @ (x - x_opt))[_shuffle]
+    c1, c2, c3, c4, c5, c6 = _hybrid_chunks(
+        y, (0.1, 0.1, 0.2, 0.2, 0.2, 0.2), (1, 1, 1, 1, 1, 2)
+    )
+    return (
+        hgbat((5.0 / 100.0) * c1)
+        + cec2017_katsuura((5.0 / 100.0) * c2)
+        + ackley(c3)
+        + cec_rastrigin((5.12 / 100.0) * c4)
+        + modified_schwefel(10.0 * c5)
+        + schaffer_f7(y[: c6.shape[-1]])
+        + 0.0 * jnp.sum(y)
+        + f_opt
+    )

--- a/src/bbob_jax/_src/composition.py
+++ b/src/bbob_jax/_src/composition.py
@@ -5,8 +5,12 @@ Provides the base kernels used inside the CEC 2005 functions
 ``cec2005_weierstrass``) and the CEC 2017 functions
 (``cec_bent_cigar``, ``zakharov``, ``cec_rosenbrock``,
 ``cec_rastrigin``, ``schaffer_f7``, ``levy``,
-``modified_schwefel``), plus the differentiable CEC 2005
-hybrid composition used by F15-F25 and its ``_f_max``
+``modified_schwefel``, ``high_conditioned_elliptic``,
+``discus``, ``expanded_schaffer_f6``,
+``expanded_griewank_rosenbrock``, ``hgbat``,
+``cec2017_katsuura``), the CEC 2017 hybrid chunk partitioning
+(``cec2017_hybrid_partition``), plus the differentiable CEC
+2005 hybrid composition used by F15-F25 and its ``_f_max``
 precomputation. Used by the CEC suites only; the BBOB
 transformations live in ``transforms.py``.
 
@@ -20,9 +24,11 @@ using ``sj.sqrt`` because the latter maps NaN to 0.
 #                                                                       Modules
 # =============================================================================
 
-# Third-party
+# Standard
+import math
 from typing import cast
 
+# Third-party
 import jax
 import jax.numpy as jnp
 import softjax as sj
@@ -329,6 +335,229 @@ def modified_schwefel(x: jax.Array) -> jax.Array:
     g = jnp.where(z > 500.0, g_high, jnp.where(z < -500.0, g_low, g_mid))
     g_ref = mid(jnp.asarray(4.209687462275036e2, dtype=x.dtype))
     return g_ref * ndim - jnp.sum(g)
+
+
+def high_conditioned_elliptic(x: jax.Array) -> jax.Array:
+    """High Conditioned Elliptic kernel. Minimum 0 at origin.
+
+    ``sum(10^(6i/(D-1)) * x_i^2)`` (0-based ``i``); the reference
+    divides by ``nx - 1``, which is undefined behavior at ``nx = 1``
+    — here the denominator is clamped to 1 (cf. ``cec2005.f3``).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    ndim = x.shape[-1]
+    exponents = jnp.arange(ndim, dtype=x.dtype) / max(ndim - 1, 1)
+    return jnp.sum(10.0 ** (6.0 * exponents) * jnp.square(x))
+
+
+def discus(x: jax.Array) -> jax.Array:
+    """Discus kernel. Minimum 0 at origin.
+
+    ``10^6 * x_1^2 + sum(x_i^2)`` — the counterpart of
+    ``cec_bent_cigar`` (not to be confused with the full BBOB
+    function ``discuss`` in ``bbob.py``).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    return 1e6 * x[0] ** 2 + jnp.sum(x[1:] ** 2)
+
+
+def expanded_schaffer_f6(x: jax.Array) -> jax.Array:
+    """Expanded Schaffer's F6 kernel. Minimum 0 at origin.
+
+    Chains :func:`scaffer_f6` over consecutive pairs with
+    wrap-around: ``g(x_1,x_2) + ... + g(x_{D-1},x_D) + g(x_D,x_1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    return jnp.sum(scaffer_f6(x, jnp.roll(x, -1)))
+
+
+def expanded_griewank_rosenbrock(x: jax.Array) -> jax.Array:
+    """Expanded Griewank-plus-Rosenbrock kernel. Minimum 0 at origin.
+
+    Griewank applied to consecutive-pair Rosenbrock terms with
+    wrap-around, on ``w = x + 1`` (the reference code's "shift to
+    origin" re-centering).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    w = x + 1.0
+    w_next = jnp.roll(w, -1)
+    t = 100.0 * (w**2 - w_next) ** 2 + (w - 1.0) ** 2
+    return jnp.sum(t**2 / 4000.0 - jnp.cos(t) + 1.0)
+
+
+def hgbat(x: jax.Array) -> jax.Array:
+    """HGBat kernel (Hans-Georg Beyer). Minimum 0 at origin.
+
+    ``|r2^2 - s^2|^(1/2) + (0.5 r2 + s)/D + 0.5`` on ``z = x - 1``
+    (re-centered so the original all-minus-ones optimum lands at
+    the origin), with ``r2 = sum(z^2)``, ``s = sum(z)``. At the
+    optimum ``r2^2 - s^2 = 0`` exactly, where the half-power's
+    gradient is infinite — the guard ``sqrt(|v| + eps) - sqrt(eps)``
+    keeps the gradient finite, the optimum value exactly 0, and the
+    error elsewhere below ``sqrt(eps)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    ndim = x.shape[-1]
+    z = x - 1.0
+    r2 = jnp.sum(jnp.square(z))
+    s = jnp.sum(z)
+    v = jnp.abs(r2**2 - s**2)
+    root = jnp.sqrt(v + 1e-12) - jnp.sqrt(jnp.asarray(1e-12, dtype=x.dtype))
+    return root + (0.5 * r2 + s) / ndim + 0.5
+
+
+def cec2017_katsuura(x: jax.Array) -> jax.Array:
+    """Katsuura kernel with CEC 2017 parameters. Minimum 0 at origin.
+
+    ``(10/D^2) * prod(1 + i * sum_j |2^j x_i - round(2^j x_i)|/2^j)
+    ^(10/D^1.2) - 10/D^2`` with ``j = 1..32``. Plain ``jnp.round``
+    (zero gradient) as in the BBOB ``katsuura``; the remaining terms
+    have well-defined gradients almost everywhere.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape ``(ndim,)``.
+
+    Returns
+    -------
+    jax.Array
+        Scalar function value.
+    """
+    ndim = x.shape[-1]
+    j_pow = 2.0 ** jnp.arange(1, 33, dtype=x.dtype)  # (32,)
+    scaled = j_pow[:, None] * x[None, :]  # (32, ndim)
+    frac_dist = jnp.abs(scaled - jnp.round(scaled)) / j_pow[:, None]
+    bracket = 1.0 + jnp.arange(1, ndim + 1, dtype=x.dtype) * jnp.sum(
+        frac_dist, axis=0
+    )
+    prod = jnp.prod(bracket) ** (10.0 / ndim**1.2)
+    scale = 10.0 / ndim**2
+    return cast(jax.Array, scale * prod - scale)
+
+
+#                                                  CEC 2017 hybrid partitioning
+# =============================================================================
+
+
+def cec2017_hybrid_partition(
+    ndim: int,
+    proportions: tuple[float, ...],
+    min_sizes: tuple[int, ...],
+) -> tuple[int, ...]:
+    """Split ``ndim`` into per-kernel chunk sizes for a hybrid function.
+
+    Primary rule is the reference code's: ``ceil(p_i * ndim)`` for
+    all but the last chunk (bit-identical to the C ``ceil`` since
+    Python floats are IEEE doubles), remainder to the last. At every
+    officially supported dimension (multiples of 10, where the
+    products are integral) this is an exact proportional split.
+
+    At other dimensions the ceil rule can violate ``min_sizes``
+    (e.g. a negative last chunk — undefined behavior in the
+    reference); there a largest-remainder split with ``min_sizes``
+    floors is used instead (quota ``p_i * ndim``, floor clamped to
+    ``min_sizes[i]``, leftovers by descending fractional remainder,
+    ties to the lowest index). ``min_sizes`` is 1 per kernel, or 2
+    for Schaffer F7 sub-kernels (undefined below two dimensions).
+
+    Parameters
+    ----------
+    ndim : int
+        Total number of dimensions to split.
+    proportions : tuple[float, ...]
+        Official per-kernel proportions (sum to 1).
+    min_sizes : tuple[int, ...]
+        Smallest admissible size per chunk.
+
+    Returns
+    -------
+    tuple[int, ...]
+        Chunk sizes summing to ``ndim``.
+
+    Raises
+    ------
+    ValueError
+        If no admissible split exists (``ndim`` below the
+        function's ``min_ndim``).
+    """
+    n_kernels = len(proportions)
+    ceil_sizes = [math.ceil(p * ndim) for p in proportions[:-1]]
+    ceil_sizes.append(ndim - sum(ceil_sizes))
+    if all(s >= m for s, m in zip(ceil_sizes, min_sizes, strict=False)):
+        return tuple(ceil_sizes)
+
+    quotas = [p * ndim for p in proportions]
+    sizes = [
+        max(m, math.floor(q)) for m, q in zip(min_sizes, quotas, strict=False)
+    ]
+    remaining = ndim - sum(sizes)
+    if remaining < 0:
+        raise ValueError(
+            f"cannot split ndim={ndim} into {n_kernels} chunks with "
+            f"minimum sizes {min_sizes}"
+        )
+    order = sorted(
+        range(n_kernels),
+        key=lambda i: (-(quotas[i] - math.floor(quotas[i])), i),
+    )
+    while remaining > 0:
+        for i in order:
+            if remaining == 0:
+                break
+            sizes[i] += 1
+            remaining -= 1
+    if any(s < m for s, m in zip(sizes, min_sizes, strict=False)):
+        raise ValueError(
+            f"cannot split ndim={ndim} into {n_kernels} chunks with "
+            f"minimum sizes {min_sizes}"
+        )
+    return tuple(sizes)
 
 
 def hybrid_composition(

--- a/src/bbob_jax/_src/factories.py
+++ b/src/bbob_jax/_src/factories.py
@@ -464,6 +464,84 @@ def make_cec2017(
     )
 
 
+def make_cec2017_hybrid(
+    fn: Callable,
+    ndim: int,
+    key: PRNGKeyArray | None = None,
+    min_ndim: int = 1,
+    deterministic: bool = False,
+) -> BBOBFn:
+    """Factory for CEC 2017 hybrid functions (F11-F20).
+
+    Beyond the shift (sampled in ``[-80, 80]^D``), rotations and
+    ``f_opt``, hybrids carry a dimension permutation bound as
+    ``_shuffle`` (the official suite ships shuffle data files;
+    here it is sampled from the key). ``deterministic=True``
+    uses the identity permutation alongside zero shift, identity
+    rotations and zero ``f_opt``.
+
+    Parameters
+    ----------
+    fn : Callable
+        Base CEC 2017 hybrid function.
+    ndim : int
+        Number of input dimensions.
+    key : PRNGKeyArray or None, optional
+        JAX random key. Required when ``deterministic`` is
+        False; ignored otherwise.
+    min_ndim : int, optional
+        Smallest ``ndim`` the hybrid is defined for (at least
+        one dimension per subcomponent kernel; more when the
+        chunk split demands it — see
+        ``cec2017_hybrid_partition``).
+    deterministic : bool, optional
+        When True, use zero shift, identity rotations, identity
+        shuffle and zero ``f_opt`` instead of sampling.
+
+    Returns
+    -------
+    BBOBFn
+        Tuple of (partial function, optimal value).
+
+    Raises
+    ------
+    ValueError
+        If ``ndim < min_ndim``.
+    """
+    if ndim < min_ndim:
+        raise ValueError(
+            f"{getattr(fn, '__name__', fn)} requires ndim >= {min_ndim}, "
+            f"got {ndim}"
+        )
+    if deterministic:
+        f_opt_val = jnp.array(0.0)
+        eye = jnp.eye(ndim)
+        return (
+            Partial(
+                fn,
+                x_opt=jnp.zeros(ndim),
+                f_opt=f_opt_val,
+                R=eye,
+                Q=eye,
+                _shuffle=jnp.arange(ndim),
+            ),
+            f_opt_val,
+        )
+    if key is None:
+        raise ValueError("key is required when deterministic=False")
+
+    key_r, key_q, key_s, key_x, key_f = jr.split(key, 5)
+    x_opt = xopt(key=key_x, ndim=ndim, minval=-80.0, maxval=80.0)
+    R = rotation_matrix(ndim, key_r)
+    Q = rotation_matrix(ndim, key_q)
+    shuffle = jr.permutation(key_s, ndim)
+    f_opt_val = fopt(key_f)
+    return (
+        Partial(fn, x_opt=x_opt, f_opt=f_opt_val, R=R, Q=Q, _shuffle=shuffle),
+        f_opt_val,
+    )
+
+
 def make_cec2005_conditioned(
     fn: Callable,
     ndim: int,

--- a/src/bbob_jax/_src/spec.py
+++ b/src/bbob_jax/_src/spec.py
@@ -102,6 +102,7 @@ from bbob_jax._src.factories import (
     make_cec2005,
     make_cec2005_conditioned,
     make_cec2017,
+    make_cec2017_hybrid,
 )
 
 #                                                          Authorship & Credits
@@ -1002,6 +1003,92 @@ CEC2017_SPECS: tuple[FunctionSpec, ...] = (
         maker=Partial(make_cec2017, fn=cec2017.f10),
         tags=_cec2017_tags(),
         bounds=CEC2017_BOUNDS,
+    ),
+    # Hybrids F11-F20: min_ndim is at least one dimension per subcomponent
+    # kernel; f14 and f20 need more because their Schaffer F7 chunk must
+    # hold two dimensions under the chunk-partition rule (see
+    # cec2017_hybrid_partition).
+    FunctionSpec(
+        name="cec2017_f11",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f11, min_ndim=3),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=3,
+    ),
+    FunctionSpec(
+        name="cec2017_f12",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f12, min_ndim=3),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=3,
+    ),
+    FunctionSpec(
+        name="cec2017_f13",
+        suite="cec2017",
+        # min_ndim 4, not 3: the Lunacek chunk needs two dimensions
+        # (its depth factor is negative at one — NaN in the reference).
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f13, min_ndim=4),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=4,
+    ),
+    FunctionSpec(
+        name="cec2017_f14",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f14, min_ndim=6),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=6,
+    ),
+    FunctionSpec(
+        name="cec2017_f15",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f15, min_ndim=4),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=4,
+    ),
+    FunctionSpec(
+        name="cec2017_f16",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f16, min_ndim=4),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=4,
+    ),
+    FunctionSpec(
+        name="cec2017_f17",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f17, min_ndim=5),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=5,
+    ),
+    FunctionSpec(
+        name="cec2017_f18",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f18, min_ndim=5),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=5,
+    ),
+    FunctionSpec(
+        name="cec2017_f19",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f19, min_ndim=5),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=5,
+    ),
+    FunctionSpec(
+        name="cec2017_f20",
+        suite="cec2017",
+        maker=Partial(make_cec2017_hybrid, fn=cec2017.f20, min_ndim=7),
+        tags=_cec2017_tags(hybrid=True),
+        bounds=CEC2017_BOUNDS,
+        min_ndim=7,
     ),
 )
 

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -36,10 +36,10 @@ def test_no_key_overlap():
 
 
 def test_cec2017_bounds_keys():
-    """cec2017_bounds covers F1 and F3-F10 (F2 was withdrawn); the
-    hybrid and composition waves extend this set."""
+    """cec2017_bounds covers F1 and F3-F20 (F2 was withdrawn); the
+    composition wave extends this set."""
     assert set(cec2017_bounds.keys()) == {
-        f"cec2017_f{i}" for i in range(1, 11) if i != 2
+        f"cec2017_f{i}" for i in range(1, 21) if i != 2
     }
 
 

--- a/tests/test_cec2017.py
+++ b/tests/test_cec2017.py
@@ -1,4 +1,4 @@
-"""Tests for CEC 2017 benchmark functions (F1, F3-F10).
+"""Tests for CEC 2017 benchmark functions (F1, F3-F20).
 
 These tests validate JAX compatibility (jit, vmap, grad), NaN propagation
 and basic sanity checks. They do NOT validate that results match the
@@ -7,13 +7,17 @@ official CEC 2017 data files — instances are seed-generated (see the
 official reference data accompanies the composition wave.
 """
 
+import math
+
 import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
 from bbob_jax import cec2017_registry, cec2017_registry_original
+from bbob_jax._src.composition import cec2017_hybrid_partition
 from bbob_jax._src.mesh import _create_mesh
+from bbob_jax._src.spec import SPEC_BY_NAME
 
 pytest_cec2017 = [
     pytest.param(name, fn, id=f"cec2017_registry::{name}")
@@ -27,10 +31,47 @@ all_cec2017 = pytest_cec2017 + pytest_cec2017_original
 
 dimensions = [2, 3, 5, 10, 20]
 
+# Chunk proportions and minimum chunk sizes per hybrid — mirrors the
+# tables inside cec2017.py f11-f20 (pinned here so a silent change to
+# either side fails a test).
+HYBRID_PARTITIONS = {
+    "cec2017_f11": ((0.2, 0.4, 0.4), (1, 1, 1)),
+    "cec2017_f12": ((0.3, 0.3, 0.4), (1, 1, 1)),
+    "cec2017_f13": ((0.3, 0.3, 0.4), (1, 1, 2)),
+    "cec2017_f14": ((0.2, 0.2, 0.2, 0.4), (1, 1, 2, 1)),
+    "cec2017_f15": ((0.2, 0.2, 0.3, 0.3), (1, 1, 1, 1)),
+    "cec2017_f16": ((0.2, 0.2, 0.3, 0.3), (1, 1, 1, 1)),
+    "cec2017_f17": ((0.1, 0.2, 0.2, 0.2, 0.3), (1, 1, 1, 1, 1)),
+    "cec2017_f18": ((0.2, 0.2, 0.2, 0.2, 0.2), (1, 1, 1, 1, 1)),
+    "cec2017_f19": ((0.2, 0.2, 0.2, 0.2, 0.2), (1, 1, 1, 1, 1)),
+    "cec2017_f20": ((0.1, 0.1, 0.2, 0.2, 0.2, 0.2), (1, 1, 1, 1, 1, 2)),
+}
+
+MIN_NDIMS = {
+    "cec2017_f6": 2,
+    "cec2017_f11": 3,
+    "cec2017_f12": 3,
+    "cec2017_f13": 4,
+    "cec2017_f14": 6,
+    "cec2017_f15": 4,
+    "cec2017_f16": 4,
+    "cec2017_f17": 5,
+    "cec2017_f18": 5,
+    "cec2017_f19": 5,
+    "cec2017_f20": 7,
+}
+
+
+def _skip_below_min_ndim(name: str, dim: int) -> None:
+    min_ndim = SPEC_BY_NAME[name].min_ndim
+    if dim < min_ndim:
+        pytest.skip(f"{name} needs ndim >= {min_ndim}")
+
 
 @pytest.mark.parametrize("name,fn", all_cec2017)
 @pytest.mark.parametrize("dim", dimensions)
 def test_function_output(name, fn, dim):
+    _skip_below_min_ndim(name, dim)
     key = jr.key(0)
     x = jr.uniform(key, shape=(dim,), minval=-100.0, maxval=100.0)
     fn_func, _ = fn(ndim=dim, key=key)
@@ -42,6 +83,7 @@ def test_function_output(name, fn, dim):
 @pytest.mark.parametrize("name,fn", all_cec2017)
 @pytest.mark.parametrize("dim", dimensions)
 def test_function_output_jit(name, fn, dim):
+    _skip_below_min_ndim(name, dim)
     key = jr.key(0)
     x = jr.uniform(key, shape=(dim,), minval=-100.0, maxval=100.0)
     fn_func, _ = fn(ndim=dim, key=key)
@@ -61,6 +103,7 @@ def test_function_nan_propagates(name, fn, dim):
     epsilon-guarded ``jnp.sqrt`` instead of ``sj.sqrt`` (which maps
     NaN to 0).
     """
+    _skip_below_min_ndim(name, dim)
     key = jr.key(0)
     fn_func, _ = fn(ndim=dim, key=key)
 
@@ -84,6 +127,7 @@ def test_function_nan_propagates(name, fn, dim):
 @pytest.mark.parametrize("dim", [2])
 @pytest.mark.parametrize("seed", [1, 2])
 def test_function_vmap(name, fn, dim, seed):
+    _skip_below_min_ndim(name, dim)
     key = jr.key(seed)
     fn_func, _ = fn(ndim=dim, key=key)
     _, _, Z = _create_mesh(fn_func, bounds=(-100.0, 100.0), px=50)
@@ -94,6 +138,7 @@ def test_function_vmap(name, fn, dim, seed):
 @pytest.mark.parametrize("dim", dimensions)
 @pytest.mark.parametrize("seed", [1, 2])
 def test_function_grad(name, fn, dim, seed):
+    _skip_below_min_ndim(name, dim)
     key = jr.key(seed)
     key_x, key_fn = jr.split(key)
     x = jr.uniform(key_x, shape=(10, dim), minval=-100.0, maxval=100.0)
@@ -137,6 +182,61 @@ def test_f5_f8_same_structure_different_instance(dim):
 
 @pytest.mark.parametrize("name,fn", pytest_cec2017_original)
 def test_deterministic_needs_no_key(name, fn):
-    fn_func, f_opt = fn(ndim=3)
-    assert jnp.isfinite(fn_func(jnp.ones(3)))
+    ndim = max(3, SPEC_BY_NAME[name].min_ndim)
+    fn_func, f_opt = fn(ndim=ndim)
+    assert jnp.isfinite(fn_func(jnp.ones(ndim)))
     assert f_opt == 0.0
+
+
+#                                                     Hybrid chunk partitioning
+# =============================================================================
+
+
+def test_partition_matches_reference_ceil_at_official_dims():
+    """At the officially supported dimensions the split must equal the
+    reference code's ceil rule (which is exactly proportional there)."""
+    for name, (props, mins) in HYBRID_PARTITIONS.items():
+        for dim in (10, 20, 30, 50, 100):
+            sizes = cec2017_hybrid_partition(dim, props, mins)
+            ceil_sizes = [math.ceil(p * dim) for p in props[:-1]]
+            ceil_sizes.append(dim - sum(ceil_sizes))
+            assert list(sizes) == ceil_sizes, (name, dim, sizes)
+            assert sizes == tuple(int(p * dim) for p in props), (name, dim)
+
+
+def test_partition_valid_for_all_supported_dims():
+    """Every dim >= min_ndim yields chunks summing to dim and meeting
+    the per-kernel minimum sizes (the ceil rule alone is ill-defined at
+    e.g. dim=11 for f20 — the repair split must cover those)."""
+    for name, (props, mins) in HYBRID_PARTITIONS.items():
+        min_ndim = MIN_NDIMS[name]
+        for dim in range(min_ndim, 121):
+            sizes = cec2017_hybrid_partition(dim, props, mins)
+            assert sum(sizes) == dim, (name, dim, sizes)
+            assert all(s >= m for s, m in zip(sizes, mins)), (
+                name,
+                dim,
+                sizes,
+            )
+
+
+def test_partition_raises_below_min_ndim():
+    for name, (props, mins) in HYBRID_PARTITIONS.items():
+        with pytest.raises(ValueError):
+            cec2017_hybrid_partition(MIN_NDIMS[name] - 1, props, mins)
+
+
+def test_min_ndim_pins():
+    """The spec table's min_ndim matches the smallest partition-valid
+    dimension (recorded here so either side changing fails loudly)."""
+    for name, min_ndim in MIN_NDIMS.items():
+        assert SPEC_BY_NAME[name].min_ndim == min_ndim, name
+
+
+@pytest.mark.parametrize("name", sorted(MIN_NDIMS))
+def test_makers_raise_below_min_ndim(name):
+    min_ndim = MIN_NDIMS[name]
+    with pytest.raises(ValueError, match=f"ndim >= {min_ndim}"):
+        cec2017_registry[name](ndim=min_ndim - 1, key=jr.key(0))
+    with pytest.raises(ValueError, match=f"ndim >= {min_ndim}"):
+        cec2017_registry_original[name](ndim=min_ndim - 1)

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -68,7 +68,9 @@ def test_missing_key_raises():
 @pytest.mark.parametrize("name", BBOB_NAMES + CEC_NAMES + CEC2017_NAMES)
 def test_problem_fields_match_metadata_dicts(name):
     """Problem bundles the same facts the separate dicts expose."""
-    p = problem(name, ndim=3, key=jr.key(0))
+    # ndim 20 clears every cec2017 min_ndim (hybrids need up to 7)
+    ndim = 20 if name in CEC2017_NAMES else 3
+    p = problem(name, ndim=ndim, key=jr.key(0))
     if name in BBOB_NAMES:
         assert p.bounds == bbob_bounds[name]
         assert p.tags == function_characteristics[name]
@@ -181,6 +183,9 @@ def test_cec2017_global_minimum_at_x_opt(name, dim, deterministic):
     the resolver places x_opt at the rotated all-ones point, so this
     also pins the Levy optimum-displacement handling.
     """
+    min_ndim = problem(name, ndim=20, key=jr.key(0)).min_ndim
+    if dim < min_ndim:
+        pytest.skip(f"{name} needs ndim >= {min_ndim}")
     p = problem(name, ndim=dim, key=jr.key(0), deterministic=deterministic)
     result = p.fn(p.x_opt)
     assert jnp.isclose(result, p.f_opt, atol=1e-5), (


### PR DESCRIPTION
## CEC 2017 wave 2/3: hybrid functions F11–F20

Stacked on #18 (wave 1). Adds the ten hybrid functions plus the machinery they need; wave 3 brings the compositions F21–F30, the official-data cross-check script and docs/plots.

### Structure

Each hybrid shifts, rotates and **shuffles** the input (`y = (R @ (x − o))[shuffle]`; the permutation is a sampled instance parameter bound as `_shuffle`, identity in deterministic mode), splits it into contiguous chunks by the official proportions, and feeds each chunk to one kernel with its kernel-specific shrink. New kernels in composition.py: `high_conditioned_elliptic`, `discus`, `expanded_schaffer_f6`, `expanded_griewank_rosenbrock`, `hgbat`, `cec2017_katsuura` (weierstrass reuses `cec2005_weierstrass` — identical parameters).

### Chunk partitioning (`cec2017_hybrid_partition`)

The reference's `ceil(p_i·D)` split is used wherever it is well-defined — **bit-identical to the C code** (same IEEE double math), so anyone comparing against the reference or its ports (tilleyd, opfunu) at any C-sane dimension gets matching chunk sizes. But the ceil rule is ill-defined off the official dims (F20 at D=11 yields a *negative* last chunk — out-of-bounds UB in the C code); at exactly those dims a largest-remainder split with per-kernel minimum sizes takes over. At every officially supported dimension (multiples of 10) both rules coincide with the exact proportional split.

`min_ndim` per function is the smallest partition-valid dimension, pinned by tests: f11/f12: 3, f13: 4, f15/f16: 4, f17/f18/f19: 5, f14: 6, f20: 7.

### Reference-code quirks, replicated faithfully (code wins)

- **Schaffer F7 sub-kernel reads the wrong coordinates** (f14, f20): the reference reads the stale global `y` buffer, i.e. the *leading* entries of the shuffled vector instead of its own chunk — its own chunk's coordinates never influence the value. This is what all published results used.
- **Lunacek sub-kernel's sign flip** (f13) keys off the leading entries of the full unshuffled shift vector (same global-buffer aliasing), and applies no rotation to its cosine term.
- **Lunacek needs a ≥2-dim chunk**: its depth factor `s = 1 − 1/(2√(D+20) − 8.2)` is negative at D=1, making `mu1` the root of a negative number — NaN in the reference as well. This bumps f13's `min_ndim` to 4.

### NaN propagation

Because the quirks (and single-coordinate Rosenbrock chunks, whose sum is empty) leave some coordinates without influence, each hybrid carries a `0.0 * jnp.sum(y)` term — an exact zero for finite inputs, gradient-neutral, but NaN-propagating. The whole suite keeps the NaN-in → NaN-out guarantee, tested per dimension.

### Tests

Battery extended with min_ndim-aware skips; new partition tests (official-dim exactness vs the ceil rule, validity sweep D=min..120, raise-below-min, min_ndim pins) and maker raise tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
