### PR TITLE
feat: BBOB-noisy suite (f101–f130) + Problem.fn_true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`bbob-jax` is a JAX implementation of the 24 BBOB (Black-Box Optimization Benchmark) noise-free functions, the 25 CEC 2005 benchmark functions, and the 29 CEC 2017 bound-constrained functions (F2 was officially withdrawn and is skipped; numbering keeps the hole). The key value-add over the original C implementations is full JAX compatibility: automatic differentiation, JIT compilation, and vectorization via `vmap`.
+`bbob-jax` is a JAX implementation of the 24 BBOB (Black-Box Optimization Benchmark) noise-free functions, the 30 BBOB-noisy functions (f101–f130), the 25 CEC 2005 benchmark functions, and the 29 CEC 2017 bound-constrained functions (F2 was officially withdrawn and is skipped; numbering keeps the hole). The key value-add over the original C implementations is full JAX compatibility: automatic differentiation, JIT compilation, and vectorization via `vmap`.
 
 ## Commands
 
@@ -26,13 +26,15 @@ make docs                  # Start MkDocs dev server
 - `problem` / `Problem` — one-lookup accessor bundling fn, x_opt, f_opt, bounds, tags, noise arity
 - `registry` — randomized BBOB factory (random x_opt, f_opt, rotation matrices)
 - `registry_original` — deterministic BBOB factory (zero x_opt, zero f_opt, identity rotations)
+- `bbob_noisy_registry` / `bbob_noisy_registry_original` — BBOB-noisy factories (names `bbob_noisy_f101`…`bbob_noisy_f130`; prefixed like CEC 2017). Every function is stochastic (`fn(x, key)`); `*_original` means deterministic *instance parameters*, noise stays stochastic
 - `cec2005_registry` — randomized CEC 2005 factory (25 functions `f1`–`f25`)
 - `cec2005_registry_original` — deterministic CEC 2005 factory
 - `cec2017_registry` / `cec2017_registry_original` — CEC 2017 factories (names `cec2017_f1`, `cec2017_f3`…; prefixed because `SPEC_BY_NAME` is a single namespace and CEC 2005 owns the bare `fN` keys)
 - `function_characteristics` — BBOB metadata dict (separable/unimodal flags per function)
+- `bbob_noisy_function_characteristics` — BBOB-noisy metadata dict (`separable`/`unimodal` describe the undisturbed base; `gaussian_noise`/`uniform_noise`/`cauchy_noise` mutually exclusive; `severe` False for f101–f106; `noise` always True)
 - `cec2005_function_characteristics` — CEC 2005 metadata dict
 - `cec2017_function_characteristics` — CEC 2017 metadata dict (`unimodal`/`multimodal`/`hybrid`/`composition`/`rotated`/`structure_modified`; no `noise` key)
-- `bbob_bounds` / `cec2005_bounds` / `cec2017_bounds` — per-function search-space bounds (also via the `bounds` submodule)
+- `bbob_bounds` / `bbob_noisy_bounds` / `cec2005_bounds` / `cec2017_bounds` — per-function search-space bounds (also via the `bounds` submodule)
 
 ### Spec Table (single source of truth)
 
@@ -62,11 +64,15 @@ bound (zero shift, identity rotations, zero f_opt).
 
 ```python
 p = bbob_jax.problem("rastrigin", ndim=2, key=jax_key)  # deterministic=True for the *_original instance
-p.fn, p.x_opt, p.f_opt, p.bounds, p.tags, p.noisy
+p.fn, p.x_opt, p.f_opt, p.bounds, p.tags, p.noisy, p.fn_true
 ```
 `fn(p.x_opt) == p.f_opt` holds for every function (documented exceptions:
-deterministic CEC compositions are degenerate). Noisy CEC functions
-(`noise` tag) are called as `fn(x, key)`. `Problem.min_ndim` is the
+deterministic CEC compositions are degenerate). Noisy functions
+(`noise` tag: the BBOB-noisy suite and CEC 2005 F4/F17/F24/F25) are
+called as `fn(x, key)`; `p.fn_true(x)` is their undisturbed value
+(base + penalty + `f_opt`, same bound instance parameters), and `fn_true`
+is `fn` itself for noise-free functions. The spec table wires this via
+`FunctionSpec.true_fn`. `Problem.min_ndim` is the
 smallest supported dimension (default 1); makers raise `ValueError` below
 it (e.g. `cec2017_f6` needs `ndim >= 2`; CEC 2017 hybrids need one
 dimension per subcomponent kernel and up to 7 where the chunk split
@@ -78,7 +84,9 @@ All 24 BBOB functions in `_src/bbob.py`, the 25 CEC 2005 functions in `_src/cec2
 ```python
 def fn(x, x_opt, f_opt, R, Q) -> jax.Array
 ```
-After partial application via the registry, the user-facing signature is just `fn(x)`. (Some factories also bind extra precomputed keyword arguments, e.g. `_mat` or `_f_max`.)
+After partial application via the registry, the user-facing signature is just `fn(x)`. (Some factories also bind extra precomputed keyword arguments, e.g. `_mat` or `_f_max`.) Noisy functions (`_src/bbob_noisy.py` f101–f130, CEC 2005 F4/F17/F24/F25) take `key` as second positional argument: `fn(x, key, x_opt, f_opt, R, Q, ...)`; their `*_true`/`f*_true` counterparts share the bound-parameter signature minus `key`.
+
+The BBOB-noisy suite replicates the legacy COCO `benchmarksnoisy.c` (cross-checked point-for-point via `scripts/crosscheck_bbob_noisy.py`, worst rel. deviation ~4e-12): noise models in `_src/noise.py` disturb the residual above the optimum, the ×100 boundary penalty and `f_opt` are added outside the noise, and residuals below 1e-8 bypass the noise (gate) so `fn(x_opt, key) == f_opt` exactly. `bbob_noisy.py` carries its own `_tosz`/`_asym` helpers replicating the legacy transforms exactly — the shared `transforms.py` variants deviate for the noiseless suite (first/last-element mask, positive-branch constants for negatives, `(i-1)/(D-1)` asymmetry exponent) and are pinned there by ADR 0001. The current COCO revival (`transform_obj_*_noise.c`) drops the gate and uses a linear penalty; legacy semantics win (see ADR 0004).
 
 BBOB functions compose transformations from `_src/transforms.py`:
 - Shift by `x_opt`, rotate with `R`/`Q`
@@ -98,23 +106,26 @@ Gradient convention: softjax (`sj.*`) straight-through estimators are used only 
 src/bbob_jax/
 ├── __init__.py          # Public exports
 ├── plotting.py          # Public plotting API (wraps _src/plotting.py)
-├── bounds.py            # Public bounds API (re-exports bbob_bounds, cec2005_bounds)
+├── bounds.py            # Public bounds API (re-exports the per-suite bounds dicts)
 └── _src/
     ├── bbob.py          # All 24 BBOB function implementations
+    ├── bbob_noisy.py    # All 30 BBOB-noisy implementations (f101–f130) + *_true bases
+    ├── noise.py         # BBOB-noisy noise models: gauss/uniform/cauchy + gate
     ├── cec2005.py       # All 25 CEC 2005 function implementations (f1–f25)
     ├── cec2017.py       # All 29 CEC 2017 function implementations (F2 withdrawn/skipped)
     ├── spec.py          # FunctionSpec table — single source of truth per function
     ├── factories.py     # Mode-parameterized makers (deterministic= flag)
-    ├── registry.py      # The six registry dicts, derived from spec.py
+    ├── registry.py      # The eight registry dicts, derived from spec.py
     ├── problem.py       # Problem record + problem() accessor
     ├── transforms.py    # BBOB transforms: tosz, tasy, lambda, penalty
     ├── composition.py   # CEC kernels (2005 + 2017) + hybrid composition machinery
     ├── sampling.py      # fopt, xopt, bernoulli_vector, rotation_matrix
     ├── mesh.py          # _create_mesh grid evaluator (matplotlib-free)
     ├── tags.py          # function_characteristics, derived from spec.py
+    ├── bbob_noisy_tags.py  # bbob_noisy_function_characteristics, derived from spec.py
     ├── cec2005_tags.py  # cec2005_function_characteristics, derived from spec.py
     ├── cec2017_tags.py  # cec2017_function_characteristics, derived from spec.py
-    ├── bounds.py        # bbob_bounds, cec2005_bounds, cec2017_bounds, derived from spec.py
+    ├── bounds.py        # per-suite bounds dicts, derived from spec.py
     └── plotting.py      # plot_2d, plot_3d (requires optional matplotlib dep)
 ```
 
@@ -122,14 +133,15 @@ Architecture decisions are recorded in `docs/adr/`.
 
 ### Testing
 
-Tests live in `tests/` (`test_example.py` for BBOB, `test_cec2005.py` for CEC 2005, `test_cec2017.py` for CEC 2017, plus `test_bounds.py`, `test_composition.py`, `test_problem.py`, `test_consistency.py`, `test_gallagher_equivalence.py`). They are parametrized over all functions × multiple dimensions × both registries. Each test validates:
+Tests live in `tests/` (`test_example.py` for BBOB, `test_bbob_noisy.py` for BBOB-noisy, `test_cec2005.py` for CEC 2005, `test_cec2017.py` for CEC 2017, plus `test_bounds.py`, `test_composition.py`, `test_problem.py`, `test_consistency.py`, `test_gallagher_equivalence.py`). They are parametrized over all functions × multiple dimensions × both registries. Each test validates:
 - Correct scalar output shape
 - JIT compilation (`jax.jit`)
 - Vectorization (`jax.vmap`)
 - Gradient computation (`jax.grad`)
-- NaN propagation (NaN in → NaN out) for BBOB and CEC 2017
+- NaN propagation (NaN in → NaN out) for BBOB, BBOB-noisy and CEC 2017
 - `fn(x_opt) == f_opt` for all suites via `problem()` (`test_problem.py`)
 - Registry/tags/bounds key-set consistency and tag schemas (`test_consistency.py`)
+- BBOB-noisy noise wiring: pinned-draw formula re-derivation per function, gate behavior, and deterministic statistical tests per noise model (`test_bbob_noisy.py`); the undisturbed path is cross-checked against the compiled legacy C by `scripts/crosscheck_bbob_noisy.py` (not in CI)
 
 `matplotlib` is an optional dependency (install group `plot`); tests don't require it.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,71 @@
+# bbob-jax
+
+JAX implementations of black-box optimization benchmark suites (BBOB
+noise-free, BBOB-noisy, CEC 2005, CEC 2017), exposing differentiable,
+JIT-able, vmap-able problem instances.
+
+## Language
+
+**Suite**:
+A published benchmark family (bbob, bbob_noisy, cec2005, cec2017). Each
+suite has its own registry pair, tag schema and bounds dict, all derived
+from the spec table.
+
+**Spec row**:
+The single `FunctionSpec` entry that defines one benchmark function —
+implementation, maker, tags, bounds, optimum resolver. Adding a function
+means adding one spec row.
+
+**Instance**:
+A concrete problem constructed by a maker from `(ndim, key)` — the
+function with sampled `x_opt`, `f_opt` and rotations bound in.
+_Avoid_: COCO's integer "instance ID" — bbob-jax instances are keyed by
+JAX PRNG keys, not by instance numbers.
+
+**Deterministic instance**:
+The instance built with `deterministic=True`: zero shift, identity
+rotations, zero `f_opt`. For noisy functions the *parameters* are
+deterministic but evaluation stays stochastic.
+_Avoid_: "noiseless instance" — determinism refers to parameters, never
+to noise.
+
+**Noisy function**:
+A function whose evaluation consumes a PRNG key (`fn(x, key)`), marked
+by the `noise` tag. Covers BBOB-noisy f101–f130 and CEC 2005
+F4/F17/F24/F25.
+
+**Undisturbed value (Ftrue)**:
+The noise-free function value — base + boundary penalty + `f_opt` — of a
+noisy function. Exposed as `Problem.fn_true`; for noise-free functions
+`fn_true` is `fn` itself. Used by harnesses to measure true progress.
+_Avoid_: "noiseless value", "clean value"
+
+**Disturbed value (Fval)**:
+What `fn(x, key)` returns for a noisy function: the noise model applied
+to the undisturbed residual, plus penalty and `f_opt`. This is all an
+optimizer is allowed to see.
+
+**Noise model**:
+One of the three BBOB-noisy stochastic transforms of the undisturbed
+residual: Gaussian (multiplicative), uniform (multiplicative), Cauchy
+(additive).
+
+**Severity**:
+The BBOB-noisy parameter regime of a noise model: *moderate*
+(f101–f106) or *severe* (f107–f130). Tagged as the boolean `severe`.
+
+**Noise gate**:
+The BBOB-noisy final adjustment: if the undisturbed residual is below
+1e-8 the undisturbed value is returned untouched; otherwise the
+disturbed value plus 1.01e-8. Guarantees `fn(x_opt, key) == f_opt`
+exactly.
+_Avoid_: "final adjustment" (the def-page term; gate is what it does)
+
+**Boundary penalty**:
+The out-of-bounds quadratic penalty term. BBOB-noisy applies it with
+factor 100 to every function; it is added outside the noise model, so
+it is never noisy.
+
+**Code-wins rule**:
+When the published definition and the official reference implementation
+disagree, replicate the reference code, quirks included.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | [**Documentation**](https://bbob-jax.readthedocs.io/)
 | [**Zenodo**](https://doi.org/10.5281/zenodo.17426894) 
 
-JAX implementations of the **BBOB** benchmark functions (Finck et al., 2009) [^1], the **CEC 2005** benchmark functions (Suganthan et al., 2005) [^4] and the **CEC 2017** benchmark functions (Awad et al., 2016) [^5] for black-box optimization.
+JAX implementations of the **BBOB** noise-free and **BBOB-noisy** benchmark functions (Finck et al., 2009) [^1][^6], the **CEC 2005** benchmark functions (Suganthan et al., 2005) [^4] and the **CEC 2017** benchmark functions (Awad et al., 2016) [^5] for black-box optimization.
 
 **First publication:** October 17, 2025
 
@@ -13,11 +13,11 @@ JAX implementations of the **BBOB** benchmark functions (Finck et al., 2009) [^1
 
 ## Summary
 
-`bbob-jax` is a pure-[JAX](https://github.com/jax-ml/jax) reimplementation of three standard black-box optimization benchmark suites: the 24 noise-free **BBOB** functions (Finck et al., 2009), the 25 **CEC 2005** real-parameter functions (Suganthan et al., 2005) and the 29 **CEC 2017** bound-constrained functions (Awad et al., 2016; F2 was officially withdrawn). Every function is differentiable, JIT-compilable, and vectorizable via `vmap`, and is exposed through a simple registry that returns a ready-to-call objective together with its global minimum, as well as a `problem()` accessor that additionally bundles the optimum location, search-space bounds and metadata tags in one lookup. Both randomized (shifted and rotated) and deterministic factory variants are provided.
+`bbob-jax` is a pure-[JAX](https://github.com/jax-ml/jax) reimplementation of four standard black-box optimization benchmark suites: the 24 noise-free **BBOB** functions (Finck et al., 2009), the 30 **BBOB-noisy** functions f101–f130 (Finck et al., 2009), the 25 **CEC 2005** real-parameter functions (Suganthan et al., 2005) and the 29 **CEC 2017** bound-constrained functions (Awad et al., 2016; F2 was officially withdrawn). Every function is differentiable, JIT-compilable, and vectorizable via `vmap`, and is exposed through a simple registry that returns a ready-to-call objective together with its global minimum, as well as a `problem()` accessor that additionally bundles the optimum location, search-space bounds and metadata tags in one lookup. Both randomized (shifted and rotated) and deterministic factory variants are provided. Noisy functions are called as `fn(x, key)`; their undisturbed value is exposed as `Problem.fn_true` for COCO-style true-progress measurement.
 
 ## Statement of need
 
-The BBOB and CEC benchmark suites are cornerstones of black-box optimization research. This repository provides JAX reimplementations of all three: the 24 BBOB noise-free functions originally written in C, the 25 CEC 2005 real-parameter functions, and the 29 CEC 2017 bound-constrained functions (simple, hybrid and composition). Translating these suites to JAX enables automatic differentiation, just-in-time (JIT) compilation, and XLA-accelerated performance — making them ideal for research in optimization, machine learning, and evolutionary algorithms.
+The BBOB and CEC benchmark suites are cornerstones of black-box optimization research. This repository provides JAX reimplementations of all four: the 24 BBOB noise-free functions originally written in C, the 30 BBOB-noisy functions (Gaussian, uniform and Cauchy noise models at moderate and severe severity), the 25 CEC 2005 real-parameter functions, and the 29 CEC 2017 bound-constrained functions (simple, hybrid and composition). Translating these suites to JAX enables automatic differentiation, just-in-time (JIT) compilation, and XLA-accelerated performance — making them ideal for research in optimization, machine learning, and evolutionary algorithms.
 
 <div align="center">
   <img src="img/bbob_functions_overview_3d.png" alt="BBOB functions 3D overview" width="80%">
@@ -122,6 +122,8 @@ This project is licensed under the BSD 3-Clause License. See [LICENSE](https://g
 [^4]: Suganthan, P. N., Hansen, N., Liang, J. J., and Deb, K. (2005), Problem Definitions and Evaluation Criteria for the CEC 2005 Special Session on Real-Parameter Optimization.
 
 [^5]: Awad, N. H., Ali, M. Z., Liang, J. J., Qu, B. Y., and Suganthan, P. N. (2016), Problem Definitions and Evaluation Criteria for the CEC 2017 Special Session and Competition on Single Objective Real-Parameter Numerical Optimization.
+
+[^6]: Finck, S., Hansen, N., Ros, R., and Auger, A. (2009), [Real-parameter black-box optimization benchmarking 2009: Noisy functions definitions](https://inria.hal.science/inria-00369466v2/document), INRIA.
 
 ## Related repositories
 

--- a/docs/adr/0004-bbob-noisy-suite-and-fn-true.md
+++ b/docs/adr/0004-bbob-noisy-suite-and-fn-true.md
@@ -1,0 +1,45 @@
+# BBOB-noisy suite: fn_true on every Problem, statistical noise verification
+
+Status: accepted
+
+The BBOB-noisy suite (f101–f130, registry keys `bbob_noisy_f101`…
+`bbob_noisy_f130`) exposes the noisy evaluation as `fn(x, key)` — the
+established CEC 2005 noisy convention — and additionally exposes the
+undisturbed value (Ftrue) as a new `Problem.fn_true` field. `fn_true`
+is uniform across all suites: for noise-free functions it is `fn`
+itself; the four CEC 2005 noisy functions (F4/F17/F24/F25) were
+retrofitted with an undisturbed path. Rationale: COCO-style evaluation
+measures targets on Ftrue while the optimizer sees Fval, and Ftrue is
+unrecoverable from the noise-free suite because the noisy base
+parametrizations differ (conditioning, ×100 boundary penalty on every
+function).
+
+## Considered options
+
+- **Optional key** (`fn(x)` → Ftrue, `fn(x, key)` → Fval): rejected —
+  breaks the CEC 2005 required-key convention, and a forgotten key
+  silently benchmarks against the noiseless function.
+- **Not exposing Ftrue**: rejected — true-progress metrics (ERT-style)
+  become impossible downstream.
+
+## Verification
+
+The deterministic Ftrue path is cross-checked against the compiled
+legacy C reference (`benchmarksnoisy.c`) by binding reference-derived
+instance parameters into the raw fns, as for CEC 2017 (ADR 0003):
+`scripts/crosscheck_bbob_noisy.py`, all 30 functions at D in {2, 5, 10},
+2 instances, worst relative deviation ~4e-12 (Griewank-Rosenbrock
+accumulation-order noise; the official legacy Python deviates from the C
+by the same amount). The stochastic Fval path cannot be matched bitwise
+(the C reference uses its own RNG), so noise models are verified by
+exact formula unit tests with pinned JAX draws plus statistical tests
+against the definition. Code-wins on any definition-vs-reference
+discrepancy.
+
+Note: the *current* COCO revival (`transform_obj_*_noise.c`) deviates
+from the legacy code — it drops the noise gate and uses a linear
+(unsquared) boundary penalty. The legacy code agrees with the published
+definition on both points, so legacy semantics are kept. Also kept: the
+suite-local `_tosz`/`_asym` transforms in `bbob_noisy.py` replicate the
+reference exactly rather than reusing `transforms.py`, whose noiseless
+variants deviate and are pinned by ADR 0001.

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,11 +14,18 @@ p = problem("rastrigin", ndim=2, key=jr.key(0))
 p.fn(p.x_opt)  # == p.f_opt
 p.bounds       # (-5.0, 5.0)
 p.tags         # {"separable": False, "unimodal": False}
-p.noisy        # False — noisy CEC functions are called as fn(x, key)
+p.noisy        # False — noisy functions are called as fn(x, key)
+p.fn_true      # undisturbed value; is p.fn itself for noise-free functions
 ```
 
 Pass `deterministic=True` for the zero-shift/identity-rotation instance
 (the `*_original` registries construct the same instances).
+
+For noisy functions (`p.noisy` is `True` — the BBOB-noisy suite and CEC
+2005 F4/F17/F24/F25), `p.fn(x, key)` returns the disturbed value an
+optimizer is allowed to see, while `p.fn_true(x)` returns the undisturbed
+value (base + boundary penalty + `f_opt`) with the same bound instance
+parameters — use it to measure true progress, COCO-style.
 
 ::: bbob_jax.problem
 
@@ -170,6 +177,113 @@ Individual benchmark function APIs. Public call pattern is via the root package 
 ::: bbob_jax.katsuura
 
 ::: bbob_jax.lunacek_bi_rastrigin
+
+## BBOB-noisy Registry
+
+Centralized access to the 30 BBOB-noisy benchmark functions (f101–f130)
+and their metadata.
+
+- `bbob_jax.bbob_noisy_registry`: Randomized variants of each BBOB-noisy function (names `bbob_noisy_f101` … `bbob_noisy_f130`). Every function is stochastic and called as `fn(x, key)`. Parameters are generated from seeds rather than derived from COCO instance IDs; the deterministic undisturbed path is cross-validated point-for-point against the compiled legacy reference code with reference-derived parameters injected (`scripts/crosscheck_bbob_noisy.py`).
+- `bbob_jax.bbob_noisy_registry_original`: Deterministic *instance* variants (zero shift, identity rotations, zero `f_opt`) — the noise stays stochastic.
+- `bbob_jax.bbob_noisy_function_characteristics`: Properties per function (`separable`/`unimodal` describe the undisturbed base; `gaussian_noise`/`uniform_noise`/`cauchy_noise` mark the noise model, exactly one per function; `severe` is False for the moderate group f101–f106; `noise` is always True).
+
+The suite is eight base landscapes × three noise models: Gaussian
+(multiplicative, log-normal), uniform (multiplicative) and Cauchy
+(additive, heavy-tailed), applied to the residual above the optimum. The
+×100 boundary penalty and `f_opt` are added outside the noise. Residuals
+below `1e-8` bypass the noise entirely (the noise gate), so
+`fn(x_opt, key) == f_opt` holds exactly. Semantics follow the legacy COCO
+code (`benchmarksnoisy.c`), which matches the published definition; see
+`docs/adr/0004`.
+
+::: bbob_jax.bbob_noisy_registry
+
+::: bbob_jax.bbob_noisy_registry_original
+
+::: bbob_jax.bbob_noisy_function_characteristics
+
+## BBOB-noisy Functions
+
+Individual BBOB-noisy benchmark function APIs (f101–f130). Access via the
+registries is recommended; the registry supplies internal parameters so the
+user-facing call is just `fn(x, key)`. The `*_true` functions are the
+undisturbed bases bound as `Problem.fn_true`.
+
+::: bbob_jax._src.bbob_noisy.f101
+
+::: bbob_jax._src.bbob_noisy.f102
+
+::: bbob_jax._src.bbob_noisy.f103
+
+::: bbob_jax._src.bbob_noisy.f104
+
+::: bbob_jax._src.bbob_noisy.f105
+
+::: bbob_jax._src.bbob_noisy.f106
+
+::: bbob_jax._src.bbob_noisy.f107
+
+::: bbob_jax._src.bbob_noisy.f108
+
+::: bbob_jax._src.bbob_noisy.f109
+
+::: bbob_jax._src.bbob_noisy.f110
+
+::: bbob_jax._src.bbob_noisy.f111
+
+::: bbob_jax._src.bbob_noisy.f112
+
+::: bbob_jax._src.bbob_noisy.f113
+
+::: bbob_jax._src.bbob_noisy.f114
+
+::: bbob_jax._src.bbob_noisy.f115
+
+::: bbob_jax._src.bbob_noisy.f116
+
+::: bbob_jax._src.bbob_noisy.f117
+
+::: bbob_jax._src.bbob_noisy.f118
+
+::: bbob_jax._src.bbob_noisy.f119
+
+::: bbob_jax._src.bbob_noisy.f120
+
+::: bbob_jax._src.bbob_noisy.f121
+
+::: bbob_jax._src.bbob_noisy.f122
+
+::: bbob_jax._src.bbob_noisy.f123
+
+::: bbob_jax._src.bbob_noisy.f124
+
+::: bbob_jax._src.bbob_noisy.f125
+
+::: bbob_jax._src.bbob_noisy.f126
+
+::: bbob_jax._src.bbob_noisy.f127
+
+::: bbob_jax._src.bbob_noisy.f128
+
+::: bbob_jax._src.bbob_noisy.f129
+
+::: bbob_jax._src.bbob_noisy.f130
+
+::: bbob_jax._src.bbob_noisy.sphere_true
+
+::: bbob_jax._src.bbob_noisy.rosenbrock_true
+
+::: bbob_jax._src.bbob_noisy.step_ellipsoid_true
+
+::: bbob_jax._src.bbob_noisy.ellipsoid_true
+
+::: bbob_jax._src.bbob_noisy.different_powers_true
+
+::: bbob_jax._src.bbob_noisy.schaffer_f7_true
+
+::: bbob_jax._src.bbob_noisy.griewank_rosenbrock_true
+
+::: bbob_jax._src.bbob_noisy.gallagher_true
 
 ## CEC 2017 Registry
 

--- a/docs/usage.ipynb
+++ b/docs/usage.ipynb
@@ -329,6 +329,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "768a73c4",
+   "source": "## BBOB-noisy Suite\n\nThe 30 noisy functions f101-f130 (`bbob_noisy_f101` ...\n`bbob_noisy_f130`) are eight base landscapes disturbed by one of three\nnoise models (Gaussian, uniform or Cauchy) at moderate (f101-f106) or\nsevere (f107-f130) severity. Every function is stochastic: call as\n`fn(x, key)` -- the same instance gives a different disturbed value per\nkey. The undisturbed value is available as `Problem.fn_true` (for\nnoise-free functions `fn_true` *is* `fn`), and residuals within `1e-8`\nof the optimum bypass the noise entirely, so `fn(x_opt, key) == f_opt`\nholds exactly.\n\nTags describe the undisturbed base plus the noise configuration\n(`gaussian_noise` / `uniform_noise` / `cauchy_noise`, `severe`).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "fc29045b",
+   "source": "import jax\nimport jax.random as jr\nfrom bbob_jax import bbob_noisy_function_characteristics, problem\n\np = problem(\"bbob_noisy_f107\", ndim=3, key=jr.key(0))\nprint(\"tags:\", bbob_noisy_function_characteristics[\"bbob_noisy_f107\"])\n\nx = jnp.array([1.0, -2.0, 0.5])\n# the optimizer sees a different disturbed value per key ...\nkeys = jr.split(jr.key(1), 4)\nprint(\"disturbed:  \", jax.vmap(lambda k: p.fn(x, k))(keys))\n# ... while fn_true measures true progress, COCO-style\nprint(\"undisturbed:\", p.fn_true(x))\n\n# the noise gate makes the optimum an exact anchor\nprint(\"fn(x_opt, key) == f_opt:\", bool(p.fn(p.x_opt, jr.key(2)) == p.f_opt))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tags: {'separable': True, 'unimodal': True, 'gaussian_noise': True, 'uniform_noise': False, 'cauchy_noise': False, 'severe': True, 'noise': True}\n",
+      "disturbed:   [620.6426  610.98615 614.90576 606.56824]\n",
+      "undisturbed: 613.2613\n",
+      "fn(x_opt, key) == f_opt: True\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fad07b9b",
    "metadata": {},
    "source": [

--- a/scripts/crosscheck_bbob_noisy.py
+++ b/scripts/crosscheck_bbob_noisy.py
@@ -1,0 +1,287 @@
+"""Cross-validate the BBOB-noisy suite against the official reference code.
+
+One-off development validation (not part of CI — instances in bbob-jax are
+seed-generated, so this script instead *injects reference-derived instance
+parameters* into the bbob-jax function definitions and compares the
+deterministic undisturbed path (Ftrue) point-for-point against the compiled
+legacy C code):
+
+1. Compiles the legacy ``benchmarksnoisy.c`` (+ helpers) with a tiny driver
+   (needs ``gcc``). The driver prints ``Fopt``, ``Xopt`` and the undisturbed
+   ``Ftrue`` at probe points for a given (function, dimension, instance).
+2. Extracts the same instance's parameters (shift, rotations, Gallagher
+   peaks) from the official legacy Python ``bbobbenchmarks.py`` — the code
+   COCO's own noisy regression test uses — converting from its row-vector
+   convention (transposing rotations) to the column-vector convention of
+   the C code and bbob-jax.
+3. Binds those parameters into the bbob-jax ``*_true`` implementations via
+   ``jax.tree_util.Partial`` — exactly the parameter slots the factories
+   normally fill with sampled values — and evaluates on the same probe
+   points in ``[-5.5, 5.5]^D`` (float64; deliberately beyond the bounds to
+   exercise the x100 boundary penalty).
+4. Reports the max absolute/relative deviation per function, for both
+   legacy-Python-vs-C (extraction sanity) and bbob-jax-vs-C.
+
+The noisy path itself cannot be compared bitwise (the C reference uses its
+own RNG); it is covered by the pinned-draw and statistical tests in
+``tests/test_bbob_noisy.py``.
+
+Usage::
+
+    uv run python scripts/crosscheck_bbob_noisy.py \\
+        --ref-dir /path/to/bbob-legacy-code/c \\
+        --legacy-py /path/to/bbobbenchmarks.py
+    # ref-dir: the ``c/`` directory of the legacy BBOB code (contains
+    #   benchmarksnoisy.c, benchmarkshelper.c, benchmarksdeclare.c, ...);
+    #   mirrored e.g. at github.com/lorenzo-consoli/bbob-legacy-code.
+    # legacy-py: the official legacy Python implementation, in numbbo/coco
+    #   at code-postprocessing/aRTAplots/bbobbenchmarks.py.
+
+Options: ``--dims 2 5 10`` ``--instances 1 4`` ``--n-points 12``
+``--seed 0``.
+"""
+
+import argparse
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import numpy as np
+
+DRIVER_C = r"""
+#include <stdio.h>
+#include <stdlib.h>
+#include "bbobStructures.h"
+#include "benchmarksnoisy.h"
+
+extern int DIM;
+extern int trialid;
+extern unsigned int isInitDone;
+extern double Fopt;
+extern double *Xopt;
+extern void initbenchmarkshelper(void);
+extern void finibenchmarkshelper(void);
+extern void initbenchmarksnoisy(void);
+extern void finibenchmarksnoisy(void);
+
+int main(int argc, char **argv)
+{
+    if (argc != 5)
+        return 1;
+    int fid = atoi(argv[1]);
+    int dim = atoi(argv[2]);
+    int instance = atoi(argv[3]);
+    int npoints = atoi(argv[4]);
+    DIM = dim;
+    trialid = instance;
+    initbenchmarkshelper();
+    initbenchmarksnoisy();
+    isInitDone = 0;
+    bbobFunction fn = handlesNoisy[fid - 101];
+    double *x = (double *)malloc(sizeof(double) * dim);
+    double *ft = (double *)malloc(sizeof(double) * npoints);
+    for (int p = 0; p < npoints; p++) {
+        for (int i = 0; i < dim; i++)
+            if (scanf("%lf", &x[i]) != 1)
+                return 2;
+        TwoDoubles r = fn(x);
+        ft[p] = r.Ftrue;
+    }
+    printf("FOPT %.17g\n", Fopt);
+    printf("XOPT");
+    for (int i = 0; i < dim; i++)
+        printf(" %.17g", Xopt[i]);
+    printf("\n");
+    for (int p = 0; p < npoints; p++)
+        printf("%.17g\n", ft[p]);
+    finibenchmarksnoisy();
+    finibenchmarkshelper();
+    return 0;
+}
+"""
+
+REF_SOURCES = [
+    "benchmarksnoisy.c",
+    "benchmarkshelper.c",
+    "benchmarksdeclare.c",
+]
+
+FUNC_NUMS = list(range(101, 131))
+
+# fid -> (bbob-jax *_true implementation name, parameter-binding style)
+BASES: dict[int, tuple[str, str]] = {
+    **{fid: ("sphere_true", "shift_only") for fid in (101, 102, 103)},
+    **{fid: ("rosenbrock_true", "shift_only") for fid in (104, 105, 106)},
+    **{fid: ("sphere_true", "shift_only") for fid in (107, 108, 109)},
+    **{fid: ("rosenbrock_true", "shift_only") for fid in (110, 111, 112)},
+    **{fid: ("step_ellipsoid_true", "mat_rot") for fid in (113, 114, 115)},
+    **{fid: ("ellipsoid_true", "rotated") for fid in (116, 117, 118)},
+    **{fid: ("different_powers_true", "rotated") for fid in (119, 120, 121)},
+    **{fid: ("schaffer_f7_true", "rot_mat") for fid in (122, 123, 124)},
+    **{
+        fid: ("griewank_rosenbrock_true", "rotated_noshift")
+        for fid in (125, 126, 127)
+    },
+    **{fid: ("gallagher_true", "gallagher") for fid in (128, 129, 130)},
+}
+
+
+def compile_reference(ref_dir: Path, build_dir: Path) -> Path:
+    for name in REF_SOURCES:
+        if not (ref_dir / name).exists():
+            sys.exit(f"missing {name} in {ref_dir}")
+    driver = build_dir / "driver.c"
+    driver.write_text(DRIVER_C)
+    exe = build_dir / "bbob_noisy_ref"
+    sources = [str(driver)] + [str(ref_dir / s) for s in REF_SOURCES]
+    subprocess.run(
+        ["gcc", "-O2", "-I", str(ref_dir), "-o", str(exe)] + sources + ["-lm"],
+        check=True,
+    )
+    return exe
+
+
+def run_reference(
+    exe: Path, fid: int, dim: int, instance: int, points: np.ndarray
+) -> tuple[float, np.ndarray, np.ndarray]:
+    """Return (fopt, xopt, ftrue-at-points) from the compiled C code."""
+    payload = "\n".join(
+        " ".join(format(v, ".17g") for v in row) for row in points
+    )
+    out = subprocess.run(
+        [str(exe), str(fid), str(dim), str(instance), str(len(points))],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    fopt = float(out[0].split()[1])
+    xopt = np.array([float(v) for v in out[1].split()[1:]])
+    ftrue = np.array([float(v) for v in out[2:]])
+    return fopt, xopt, ftrue
+
+
+def load_legacy_python(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("bbobbenchmarks", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def bind_jax_params(style: str, legacy: Any, dim: int) -> dict:
+    """Map legacy-Python instance attributes to bbob-jax keyword slots.
+
+    The legacy Python evaluates row vectors (``x @ M``); bbob-jax and the
+    C code evaluate column vectors (``M @ x``), so every extracted matrix
+    is transposed.
+    """
+    import jax.numpy as jnp
+
+    eye = jnp.eye(dim, dtype=jnp.float64)
+    as_j = lambda a: jnp.asarray(np.asarray(a), dtype=jnp.float64)  # noqa
+    kw = {
+        "x_opt": as_j(legacy.xopt),
+        "f_opt": as_j(legacy.fopt),
+        "R": eye,
+        "Q": eye,
+    }
+    if style == "shift_only":
+        pass
+    elif style == "rotated":
+        kw["R"] = as_j(legacy.rotation).T
+    elif style == "rotated_noshift":
+        # griewank-rosenbrock: the legacy linearTF folds the scale into
+        # the rotation; bbob-jax applies the scale itself.
+        scale = max(1, dim**0.5 / 8.0)
+        kw["x_opt"] = jnp.zeros(dim, dtype=jnp.float64)
+        kw["R"] = as_j(legacy.linearTF).T / scale
+    elif style == "mat_rot":
+        # step ellipsoid: linearTF (applied first) and rotation (after
+        # rounding) — bbob-jax slots _mat and Q.
+        kw["Q"] = as_j(legacy.rotation).T
+        kw["_mat"] = as_j(legacy.linearTF).T
+    elif style == "rot_mat":
+        # schaffer F7: rotation (applied first) and linearTF (after the
+        # asymmetric transform) — bbob-jax slots R and _mat.
+        kw["R"] = as_j(legacy.rotation).T
+        kw["_mat"] = as_j(legacy.linearTF).T
+    elif style == "gallagher":
+        kw["R"] = as_j(legacy.rotation).T
+        kw["_gal_w"] = as_j(legacy.peakvalues)
+        kw["_gal_y_rot"] = as_j(legacy.xlocal)
+        kw["_gal_c_diags"] = as_j(legacy.arrscales)
+    else:
+        raise ValueError(style)
+    return kw
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ref-dir", type=Path, required=True)
+    parser.add_argument("--legacy-py", type=Path, required=True)
+    parser.add_argument("--dims", type=int, nargs="+", default=[2, 5, 10])
+    parser.add_argument("--instances", type=int, nargs="+", default=[1, 4])
+    parser.add_argument("--n-points", type=int, default=12)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--rel-tol", type=float, default=1e-11)
+    args = parser.parse_args()
+
+    import tempfile
+
+    import jax
+
+    jax.config.update("jax_enable_x64", True)
+    from jax.tree_util import Partial
+
+    from bbob_jax._src import bbob_noisy
+
+    bn = load_legacy_python(args.legacy_py)
+
+    worst_py = 0.0
+    worst_jax = 0.0
+    failures = []
+    with tempfile.TemporaryDirectory() as tmp:
+        exe = compile_reference(args.ref_dir, Path(tmp))
+        rng = np.random.default_rng(args.seed)
+        for dim in args.dims:
+            for instance in args.instances:
+                points = rng.uniform(-5.5, 5.5, size=(args.n_points, dim))
+                for fid in FUNC_NUMS:
+                    fopt_c, xopt_c, ftrue_c = run_reference(
+                        exe, fid, dim, instance, points
+                    )
+                    legacy = getattr(bn, f"F{fid}")(instance)
+                    _, ftrue_py = legacy._evalfull(points.copy())
+                    scale = np.maximum(np.abs(ftrue_c), 1.0)
+                    dev_py = np.max(np.abs(ftrue_py - ftrue_c) / scale)
+                    worst_py = max(worst_py, dev_py)
+
+                    impl_name, style = BASES[fid]
+                    kw = bind_jax_params(style, legacy, dim)
+                    fn = Partial(getattr(bbob_noisy, impl_name), **kw)
+                    ftrue_jax = np.array([float(fn(p)) for p in points])
+                    dev_jax = np.max(np.abs(ftrue_jax - ftrue_c) / scale)
+                    worst_jax = max(worst_jax, dev_jax)
+
+                    status = "ok"
+                    if dev_jax > args.rel_tol or dev_py > args.rel_tol:
+                        status = "FAIL"
+                        failures.append((fid, dim, instance))
+                    print(
+                        f"f{fid} D={dim} i={instance}: "
+                        f"py-vs-C {dev_py:.2e}  jax-vs-C {dev_jax:.2e}  "
+                        f"{status}"
+                    )
+    print(f"\nworst py-vs-C  rel dev: {worst_py:.3e}")
+    print(f"worst jax-vs-C rel dev: {worst_jax:.3e}")
+    if failures:
+        sys.exit(f"FAILURES: {failures}")
+    print("all comparisons within tolerance")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bbob_jax/__init__.py
+++ b/src/bbob_jax/__init__.py
@@ -33,11 +33,19 @@ from bbob_jax._src.bbob import (
     sum_of_different_powers,
     weierstrass,
 )
-from bbob_jax._src.bounds import bbob_bounds, cec2005_bounds, cec2017_bounds
+from bbob_jax._src.bbob_noisy_tags import bbob_noisy_function_characteristics
+from bbob_jax._src.bounds import (
+    bbob_bounds,
+    bbob_noisy_bounds,
+    cec2005_bounds,
+    cec2017_bounds,
+)
 from bbob_jax._src.cec2005_tags import cec2005_function_characteristics
 from bbob_jax._src.cec2017_tags import cec2017_function_characteristics
 from bbob_jax._src.problem import Problem, problem
 from bbob_jax._src.registry import (
+    bbob_noisy_registry,
+    bbob_noisy_registry_original,
     cec2005_registry,
     cec2005_registry_original,
     cec2017_registry,
@@ -61,6 +69,10 @@ __all__ = [
     "bounds",
     "registry_original",
     "function_characteristics",
+    "bbob_noisy_registry",
+    "bbob_noisy_registry_original",
+    "bbob_noisy_function_characteristics",
+    "bbob_noisy_bounds",
     "cec2005_registry",
     "cec2005_registry_original",
     "cec2005_function_characteristics",

--- a/src/bbob_jax/_src/bbob_noisy.py
+++ b/src/bbob_jax/_src/bbob_noisy.py
@@ -1,0 +1,1704 @@
+"""BBOB-noisy suite implementations (f101-f130).
+
+Thirty stochastic benchmark functions: eight base landscapes,
+each disturbed by the Gaussian, uniform or Cauchy noise model
+from ``noise.py`` at moderate (f101-f106) or severe (f107-f130)
+severity. Replicates the legacy COCO reference
+(``benchmarksnoisy.c``); the deterministic (undisturbed) path is
+cross-checked against the compiled C code.
+
+Every function follows the assembly of the reference: the noise
+model disturbs only the *residual* (the base value above the
+optimum); the boundary penalty — always ``100 * penalty(x)`` in
+this suite — and ``f_opt`` are added outside the noise, to both
+the disturbed and the undisturbed value.
+
+The undisturbed value of each base is exposed as a ``*_true``
+function with the same bound-parameter signature minus ``key``;
+:func:`bbob_jax._src.problem.problem` binds it as
+``Problem.fn_true``.
+
+The local ``_tosz`` / ``_asym`` helpers replicate the legacy
+transforms exactly (elementwise application, sign-dependent
+constants, ``i/(D-1)`` exponent). The shared ``transforms.py``
+variants deviate from the reference for the noiseless suite and
+are pinned there by ``docs/adr/0001``; they are deliberately not
+reused here.
+"""
+
+#                                                                       Modules
+# =============================================================================
+
+# Standard
+from typing import cast
+
+# Third-party
+import jax
+import jax.numpy as jnp
+import softjax as sj
+
+# Local
+from bbob_jax._src.bbob import _precompute_gallagher
+from bbob_jax._src.noise import cauchy_noise, gauss_noise, uniform_noise
+from bbob_jax._src.transforms import lambda_func, penalty
+
+#                                                          Authorship & Credits
+# =============================================================================
+__author__ = "Martin van der Schelling (M.P.vanderSchelling@tudelft.nl)"
+__credits__ = ["Martin van der Schelling"]
+__status__ = "Stable"
+# =============================================================================
+
+
+#                                                        Legacy transformations
+# =============================================================================
+
+
+def _tosz(x: jax.Array) -> jax.Array:
+    """Legacy monotone log-sine deformation (``monotoneTFosc``).
+
+    Applied elementwise to every component, with the
+    sign-dependent constants of the reference: ``(10, 7.9)`` for
+    positive inputs, ``(5.5, 3.1)`` for negative ones. Zero maps
+    to zero.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array (any shape, applied elementwise).
+
+    Returns
+    -------
+    jax.Array
+        Deformed array of the same shape.
+    """
+    eps = 1e-12  # avoid log(0) in the unselected branch
+    x_hat = jnp.log(jnp.maximum(sj.abs_st(x), eps))
+    pos = jnp.exp(
+        x_hat + 0.049 * (jnp.sin(10.0 * x_hat) + jnp.sin(7.9 * x_hat))
+    )
+    neg = -jnp.exp(
+        x_hat + 0.049 * (jnp.sin(5.5 * x_hat) + jnp.sin(3.1 * x_hat))
+    )
+    return jnp.where(x > 0, pos, jnp.where(x < 0, neg, x))
+
+
+def _asym(x: jax.Array, beta: float) -> jax.Array:
+    """Legacy asymmetric transformation.
+
+    Positive components are raised to
+    ``1 + beta * (i / (ndim - 1)) * sqrt(x_i)`` (0-based ``i``),
+    negative ones pass through — the ``i/(D-1)`` exponent of the
+    reference, not the ``(i-1)/(D-1)`` of ``transforms.tasy_func``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    beta : float
+        Asymmetry strength.
+
+    Returns
+    -------
+    jax.Array
+        Transformed array of the same shape.
+    """
+    ndim = x.shape[-1]
+    idx = jnp.arange(ndim, dtype=x.dtype)
+    x_safe = jnp.maximum(x, 0.0)
+    exponent = 1.0 + beta * (idx / max(ndim - 1, 1)) * sj.sqrt(x_safe)
+    return jnp.where(x > 0, (x_safe + 1e-99) ** exponent, x)
+
+
+#                                                                Base residuals
+# =============================================================================
+# The undisturbed base value above the optimum — no boundary penalty, no
+# f_opt. This is the quantity the noise models disturb.
+
+
+def _sphere_residual(x: jax.Array, x_opt: jax.Array) -> jax.Array:
+    """Sphere: ``sum((x - x_opt)^2)``."""
+    return jnp.sum(jnp.square(x - x_opt))
+
+
+def _rosenbrock_residual(x: jax.Array, x_opt: jax.Array) -> jax.Array:
+    """Non-rotated Rosenbrock with dimension-dependent scaling.
+
+    ``z = max(1, sqrt(D)/8) * (x - x_opt) + 1``; the bound
+    ``x_opt`` is the minimizer (the reference samples a shift and
+    scales it by 0.75; here the minimizer is sampled directly,
+    matching the noiseless suite's ``rosenbrock``).
+    """
+    ndim = x.shape[-1]
+    zmax = jnp.maximum(1.0, jnp.sqrt(ndim) / 8.0)
+    z = zmax * (x - x_opt) + 1.0
+    return jnp.sum(
+        100.0 * jnp.power(z[:-1] ** 2 - z[1:], 2) + jnp.power(z[:-1] - 1.0, 2)
+    )
+
+
+def _step_ellipsoid_residual(
+    x: jax.Array,
+    x_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None,
+) -> jax.Array:
+    """Step ellipsoid, condition 100, rounding resolution 10."""
+    ndim = x.shape[-1]
+    if _mat is None:
+        _mat = lambda_func(ndim, alpha=10.0) @ R
+    i = jnp.arange(ndim, dtype=x.dtype)
+    mult = jnp.power(100.0, i / max(ndim - 1, 1))
+
+    z_hat = _mat @ (x - x_opt)
+
+    z_dash = 0.5 + jnp.where(jnp.abs(z_hat) > 0.5, z_hat, 10 * z_hat)
+    z_dash = jnp.floor(z_dash)
+    z_dash = jnp.where(jnp.abs(z_hat) > 0.5, z_dash, z_dash / 10.0)
+
+    z = Q @ z_dash
+    return 0.1 * jnp.maximum(jnp.abs(z_hat[0]) * 1e-4, jnp.sum(mult * z**2))
+
+
+def _ellipsoid_residual(
+    x: jax.Array, x_opt: jax.Array, R: jax.Array
+) -> jax.Array:
+    """Rotated ellipsoid, condition 1e4, legacy T_osz."""
+    ndim = x.shape[-1]
+    i = jnp.arange(ndim, dtype=x.dtype)
+    weights = jnp.power(1e4, i / max(ndim - 1, 1))
+    z = _tosz(R @ (x - x_opt))
+    return jnp.sum(weights * z**2)
+
+
+def _different_powers_residual(
+    x: jax.Array, x_opt: jax.Array, R: jax.Array
+) -> jax.Array:
+    """Sum of different powers between x^2 and x^6, with sqrt."""
+    ndim = x.shape[-1]
+    z = R @ (x - x_opt)
+    i = jnp.arange(ndim, dtype=x.dtype)
+    exponents = 2.0 + 4.0 * i / max(ndim - 1, 1)
+    return cast(jax.Array, sj.sqrt(jnp.sum(sj.abs_st(z) ** exponents)))
+
+
+def _schaffer_f7_residual(
+    x: jax.Array,
+    x_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None,
+) -> jax.Array:
+    """Schaffer F7, condition 10, legacy asymmetry beta=0.5."""
+    ndim = x.shape[-1]
+    if _mat is None:
+        _mat = lambda_func(ndim, alpha=10.0) @ Q
+    z = _mat @ _asym(R @ (x - x_opt), beta=0.5)
+
+    s = sj.sqrt(z[:-1] ** 2 + z[1:] ** 2)
+    term = jnp.sum(
+        sj.sqrt(s)
+        + sj.sqrt(s) * jnp.power(jnp.sin(50.0 * jnp.power(s, 0.2)), 2)
+    )
+    return jnp.power(term / max(ndim - 1, 1), 2)
+
+
+def _griewank_rosenbrock_residual(
+    x: jax.Array, x_opt: jax.Array, R: jax.Array
+) -> jax.Array:
+    """Griewank-Rosenbrock F8F2 blocks, noisy-suite scaling.
+
+    ``1 + sum(s/4000 - cos(s)) / (D - 1)`` — a factor 10 smaller
+    than the noiseless suite's ``10 + 10 * ... `` variant. The
+    reference has no shift; the minimizer is
+    ``x_opt + (0.5 / zmax) * R.T @ ones`` (see the spec resolver).
+    """
+    ndim = x.shape[-1]
+    zmax = jnp.maximum(1.0, jnp.sqrt(ndim) / 8.0)
+    z = zmax * (R @ (x - x_opt)) + 0.5
+    s = 100.0 * (z[:-1] ** 2 - z[1:]) ** 2 + (z[:-1] - 1.0) ** 2
+    return jnp.sum(s / 4000.0 - jnp.cos(s)) / max(ndim - 1, 1) + 1.0
+
+
+def _gallagher_residual(
+    x: jax.Array,
+    x_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _gal_w: jax.Array | None,
+    _gal_y_rot: jax.Array | None,
+    _gal_c_diags: jax.Array | None,
+) -> jax.Array:
+    """Gallagher 101 Gaussian peaks, condition up to 1000."""
+    ndim = x.shape[-1]
+    if _gal_w is None:
+        w, y_rot, c_diags = _precompute_gallagher(
+            x_opt, R, Q, ndim, 101, 99, 1000.0, -5.0, 5.0
+        )
+    else:
+        assert _gal_y_rot is not None
+        assert _gal_c_diags is not None
+        w, y_rot, c_diags = _gal_w, _gal_y_rot, _gal_c_diags
+
+    rotated_diff = R @ x - y_rot  # (101, ndim)
+    exponents = -(1.0 / (2.0 * ndim)) * jnp.sum(
+        c_diags * rotated_diff**2, axis=-1
+    )
+    f = 10.0 - jnp.max(w * jnp.exp(exponents), axis=0)
+    return jnp.power(_tosz(f), 2)
+
+
+#                                                          Undisturbed variants
+# =============================================================================
+# Same bound-parameter signature as the noisy functions minus ``key``;
+# bound as ``Problem.fn_true`` with identical instance parameters.
+
+
+def sphere_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Undisturbed sphere (base of f101-f103, f107-f109).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value.
+    """
+    return _sphere_residual(x, x_opt) + 100.0 * penalty(x) + f_opt
+
+
+def rosenbrock_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Undisturbed Rosenbrock (base of f104-f106, f110-f112).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value.
+    """
+    return _rosenbrock_residual(x, x_opt) + 100.0 * penalty(x) + f_opt
+
+
+def step_ellipsoid_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None = None,
+) -> jax.Array:
+    """Undisturbed step ellipsoid (base of f113-f115).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _mat : jax.Array, optional
+        Precomputed transformation matrix (lambda @ R).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value.
+    """
+    residual = _step_ellipsoid_residual(x, x_opt, R, Q, _mat)
+    return residual + 100.0 * penalty(x) + f_opt
+
+
+def ellipsoid_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Undisturbed ellipsoid, condition 1e4 (base of f116-f118).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value.
+    """
+    return _ellipsoid_residual(x, x_opt, R) + 100.0 * penalty(x) + f_opt
+
+
+def different_powers_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Undisturbed sum of different powers (base of f119-f121).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value.
+    """
+    residual = _different_powers_residual(x, x_opt, R)
+    return residual + 100.0 * penalty(x) + f_opt
+
+
+def schaffer_f7_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None = None,
+) -> jax.Array:
+    """Undisturbed Schaffer F7, condition 10 (base of f122-f124).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _mat : jax.Array, optional
+        Precomputed transformation matrix (lambda @ Q).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value.
+    """
+    residual = _schaffer_f7_residual(x, x_opt, R, Q, _mat)
+    return residual + 100.0 * penalty(x) + f_opt
+
+
+def griewank_rosenbrock_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Undisturbed Griewank-Rosenbrock (base of f125-f127).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value.
+    """
+    residual = _griewank_rosenbrock_residual(x, x_opt, R)
+    return residual + 100.0 * penalty(x) + f_opt
+
+
+def gallagher_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _gal_w: jax.Array | None = None,
+    _gal_y_rot: jax.Array | None = None,
+    _gal_c_diags: jax.Array | None = None,
+) -> jax.Array:
+    """Undisturbed Gallagher 101 peaks (base of f128-f130).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _gal_w : jax.Array, optional
+        Precomputed peak weight vector of shape (101,).
+    _gal_y_rot : jax.Array, optional
+        Precomputed rotated peak locations ``y @ R.T``,
+        shape (101, ndim).
+    _gal_c_diags : jax.Array, optional
+        Precomputed conditioning diagonals, shape (101, ndim).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value.
+    """
+    residual = _gallagher_residual(
+        x, x_opt, R, Q, _gal_w, _gal_y_rot, _gal_c_diags
+    )
+    return residual + 100.0 * penalty(x) + f_opt
+
+
+#                                                     Moderate noise: f101-f106
+# =============================================================================
+
+
+def f101(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sphere with moderate Gaussian noise (f101).
+
+    ``gauss_noise(sphere, beta=0.01)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _sphere_residual(x, x_opt)
+    disturbed = gauss_noise(residual, key, beta=0.01)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f102(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sphere with moderate uniform noise (f102).
+
+    ``uniform_noise(sphere, alpha=0.01*(0.49+1/D), beta=0.01)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _sphere_residual(x, x_opt)
+    disturbed = uniform_noise(
+        residual, key, alpha=0.01 * (0.49 + 1.0 / ndim), beta=0.01
+    )
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f103(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sphere with moderate seldom Cauchy noise (f103).
+
+    ``cauchy_noise(sphere, alpha=0.01, p=0.05)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _sphere_residual(x, x_opt)
+    disturbed = cauchy_noise(residual, key, alpha=0.01, p=0.05)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f104(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Rosenbrock with moderate Gaussian noise (f104).
+
+    ``gauss_noise(rosenbrock, beta=0.01)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _rosenbrock_residual(x, x_opt)
+    disturbed = gauss_noise(residual, key, beta=0.01)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f105(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Rosenbrock with moderate uniform noise (f105).
+
+    ``uniform_noise(rosenbrock, alpha=0.01*(0.49+1/D), beta=0.01)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _rosenbrock_residual(x, x_opt)
+    disturbed = uniform_noise(
+        residual, key, alpha=0.01 * (0.49 + 1.0 / ndim), beta=0.01
+    )
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f106(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Rosenbrock with moderate seldom Cauchy noise (f106).
+
+    ``cauchy_noise(rosenbrock, alpha=0.01, p=0.05)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _rosenbrock_residual(x, x_opt)
+    disturbed = cauchy_noise(residual, key, alpha=0.01, p=0.05)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+#                                                       Severe noise: f107-f130
+# =============================================================================
+
+
+def f107(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sphere with Gaussian noise (f107).
+
+    ``gauss_noise(sphere, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _sphere_residual(x, x_opt)
+    disturbed = gauss_noise(residual, key, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f108(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sphere with uniform noise (f108).
+
+    ``uniform_noise(sphere, alpha=0.49+1/D, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _sphere_residual(x, x_opt)
+    disturbed = uniform_noise(residual, key, alpha=0.49 + 1.0 / ndim, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f109(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sphere with seldom Cauchy noise (f109).
+
+    ``cauchy_noise(sphere, alpha=1, p=0.2)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _sphere_residual(x, x_opt)
+    disturbed = cauchy_noise(residual, key, alpha=1.0, p=0.2)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f110(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Rosenbrock with Gaussian noise (f110).
+
+    ``gauss_noise(rosenbrock, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _rosenbrock_residual(x, x_opt)
+    disturbed = gauss_noise(residual, key, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f111(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Rosenbrock with uniform noise (f111).
+
+    ``uniform_noise(rosenbrock, alpha=0.49+1/D, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _rosenbrock_residual(x, x_opt)
+    disturbed = uniform_noise(residual, key, alpha=0.49 + 1.0 / ndim, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f112(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Rosenbrock with seldom Cauchy noise (f112).
+
+    ``cauchy_noise(rosenbrock, alpha=1, p=0.2)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _rosenbrock_residual(x, x_opt)
+    disturbed = cauchy_noise(residual, key, alpha=1.0, p=0.2)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f113(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None = None,
+) -> jax.Array:
+    """Step ellipsoid with Gaussian noise (f113).
+
+    ``gauss_noise(step_ellipsoid, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _mat : jax.Array, optional
+        Precomputed transformation matrix (lambda @ R).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _step_ellipsoid_residual(x, x_opt, R, Q, _mat)
+    disturbed = gauss_noise(residual, key, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f114(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None = None,
+) -> jax.Array:
+    """Step ellipsoid with uniform noise (f114).
+
+    ``uniform_noise(step_ellipsoid, alpha=0.49+1/D, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _mat : jax.Array, optional
+        Precomputed transformation matrix (lambda @ R).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _step_ellipsoid_residual(x, x_opt, R, Q, _mat)
+    disturbed = uniform_noise(residual, key, alpha=0.49 + 1.0 / ndim, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f115(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None = None,
+) -> jax.Array:
+    """Step ellipsoid with seldom Cauchy noise (f115).
+
+    ``cauchy_noise(step_ellipsoid, alpha=1, p=0.2)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _mat : jax.Array, optional
+        Precomputed transformation matrix (lambda @ R).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _step_ellipsoid_residual(x, x_opt, R, Q, _mat)
+    disturbed = cauchy_noise(residual, key, alpha=1.0, p=0.2)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f116(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Ellipsoid (condition 1e4) with Gaussian noise (f116).
+
+    ``gauss_noise(ellipsoid, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _ellipsoid_residual(x, x_opt, R)
+    disturbed = gauss_noise(residual, key, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f117(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Ellipsoid (condition 1e4) with uniform noise (f117).
+
+    ``uniform_noise(ellipsoid, alpha=0.49+1/D, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _ellipsoid_residual(x, x_opt, R)
+    disturbed = uniform_noise(residual, key, alpha=0.49 + 1.0 / ndim, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f118(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Ellipsoid (condition 1e4) with seldom Cauchy noise (f118).
+
+    ``cauchy_noise(ellipsoid, alpha=1, p=0.2)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _ellipsoid_residual(x, x_opt, R)
+    disturbed = cauchy_noise(residual, key, alpha=1.0, p=0.2)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f119(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sum of different powers with Gaussian noise (f119).
+
+    ``gauss_noise(different_powers, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _different_powers_residual(x, x_opt, R)
+    disturbed = gauss_noise(residual, key, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f120(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sum of different powers with uniform noise (f120).
+
+    ``uniform_noise(different_powers, alpha=0.49+1/D, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _different_powers_residual(x, x_opt, R)
+    disturbed = uniform_noise(residual, key, alpha=0.49 + 1.0 / ndim, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f121(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Sum of different powers with seldom Cauchy noise (f121).
+
+    ``cauchy_noise(different_powers, alpha=1, p=0.2)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _different_powers_residual(x, x_opt, R)
+    disturbed = cauchy_noise(residual, key, alpha=1.0, p=0.2)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f122(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None = None,
+) -> jax.Array:
+    """Schaffer F7 with Gaussian noise (f122).
+
+    ``gauss_noise(schaffer_f7, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _mat : jax.Array, optional
+        Precomputed transformation matrix (lambda @ Q).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _schaffer_f7_residual(x, x_opt, R, Q, _mat)
+    disturbed = gauss_noise(residual, key, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f123(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None = None,
+) -> jax.Array:
+    """Schaffer F7 with uniform noise (f123).
+
+    ``uniform_noise(schaffer_f7, alpha=0.49+1/D, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _mat : jax.Array, optional
+        Precomputed transformation matrix (lambda @ Q).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _schaffer_f7_residual(x, x_opt, R, Q, _mat)
+    disturbed = uniform_noise(residual, key, alpha=0.49 + 1.0 / ndim, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f124(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _mat: jax.Array | None = None,
+) -> jax.Array:
+    """Schaffer F7 with seldom Cauchy noise (f124).
+
+    ``cauchy_noise(schaffer_f7, alpha=1, p=0.2)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _mat : jax.Array, optional
+        Precomputed transformation matrix (lambda @ Q).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _schaffer_f7_residual(x, x_opt, R, Q, _mat)
+    disturbed = cauchy_noise(residual, key, alpha=1.0, p=0.2)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f125(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Griewank-Rosenbrock F8F2 with Gaussian noise (f125).
+
+    ``gauss_noise(griewank_rosenbrock, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _griewank_rosenbrock_residual(x, x_opt, R)
+    disturbed = gauss_noise(residual, key, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f126(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Griewank-Rosenbrock F8F2 with uniform noise (f126).
+
+    ``uniform_noise(griewank_rosenbrock, alpha=0.49+1/D, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _griewank_rosenbrock_residual(x, x_opt, R)
+    disturbed = uniform_noise(residual, key, alpha=0.49 + 1.0 / ndim, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f127(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Griewank-Rosenbrock F8F2 with seldom Cauchy noise (f127).
+
+    ``cauchy_noise(griewank_rosenbrock, alpha=1, p=0.2)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _griewank_rosenbrock_residual(x, x_opt, R)
+    disturbed = cauchy_noise(residual, key, alpha=1.0, p=0.2)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f128(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _gal_w: jax.Array | None = None,
+    _gal_y_rot: jax.Array | None = None,
+    _gal_c_diags: jax.Array | None = None,
+) -> jax.Array:
+    """Gallagher 101 peaks with Gaussian noise (f128).
+
+    ``gauss_noise(gallagher, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _gal_w : jax.Array, optional
+        Precomputed peak weight vector of shape (101,).
+    _gal_y_rot : jax.Array, optional
+        Precomputed rotated peak locations ``y @ R.T``,
+        shape (101, ndim).
+    _gal_c_diags : jax.Array, optional
+        Precomputed conditioning diagonals, shape (101, ndim).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _gallagher_residual(
+        x, x_opt, R, Q, _gal_w, _gal_y_rot, _gal_c_diags
+    )
+    disturbed = gauss_noise(residual, key, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f129(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _gal_w: jax.Array | None = None,
+    _gal_y_rot: jax.Array | None = None,
+    _gal_c_diags: jax.Array | None = None,
+) -> jax.Array:
+    """Gallagher 101 peaks with uniform noise (f129).
+
+    ``uniform_noise(gallagher, alpha=0.49+1/D, beta=1)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _gal_w : jax.Array, optional
+        Precomputed peak weight vector of shape (101,).
+    _gal_y_rot : jax.Array, optional
+        Precomputed rotated peak locations ``y @ R.T``,
+        shape (101, ndim).
+    _gal_c_diags : jax.Array, optional
+        Precomputed conditioning diagonals, shape (101, ndim).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    ndim = x.shape[-1]
+    residual = _gallagher_residual(
+        x, x_opt, R, Q, _gal_w, _gal_y_rot, _gal_c_diags
+    )
+    disturbed = uniform_noise(residual, key, alpha=0.49 + 1.0 / ndim, beta=1.0)
+    return disturbed + 100.0 * penalty(x) + f_opt
+
+
+def f130(
+    x: jax.Array,
+    key: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _gal_w: jax.Array | None = None,
+    _gal_y_rot: jax.Array | None = None,
+    _gal_c_diags: jax.Array | None = None,
+) -> jax.Array:
+    """Gallagher 101 peaks with seldom Cauchy noise (f130).
+
+    ``cauchy_noise(gallagher, alpha=1, p=0.2)``.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (ndim,).
+    key : jax.Array
+        JAX PRNGKey consumed by the noise model.
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix.
+    Q : jax.Array
+        Second rotation matrix.
+    _gal_w : jax.Array, optional
+        Precomputed peak weight vector of shape (101,).
+    _gal_y_rot : jax.Array, optional
+        Precomputed rotated peak locations ``y @ R.T``,
+        shape (101, ndim).
+    _gal_c_diags : jax.Array, optional
+        Precomputed conditioning diagonals, shape (101, ndim).
+
+    Returns
+    -------
+    jax.Array
+        Disturbed function value.
+    """
+    residual = _gallagher_residual(
+        x, x_opt, R, Q, _gal_w, _gal_y_rot, _gal_c_diags
+    )
+    disturbed = cauchy_noise(residual, key, alpha=1.0, p=0.2)
+    return disturbed + 100.0 * penalty(x) + f_opt

--- a/src/bbob_jax/_src/bbob_noisy_tags.py
+++ b/src/bbob_jax/_src/bbob_noisy_tags.py
@@ -1,0 +1,27 @@
+"""BBOB-noisy function characteristics metadata.
+
+Maps each BBOB-noisy function name to a dict with boolean flags
+``separable``, ``unimodal``, ``gaussian_noise``,
+``uniform_noise``, ``cauchy_noise``, ``severe`` and ``noise``.
+``separable``/``unimodal`` describe the undisturbed base
+function. Derived from the
+:class:`~bbob_jax._src.spec.FunctionSpec` table; a lookup with
+an unknown name raises ``KeyError``.
+"""
+
+#                                                                       Modules
+# =============================================================================
+
+# Local
+from bbob_jax._src.spec import BBOB_NOISY_SPECS
+
+#                                                          Authorship & Credits
+# =============================================================================
+__author__ = "Martin van der Schelling (M.P.vanderSchelling@tudelft.nl)"
+__credits__ = ["Martin van der Schelling"]
+__status__ = "Stable"
+# =============================================================================
+
+bbob_noisy_function_characteristics: dict[str, dict[str, bool]] = {
+    s.name: dict(s.tags) for s in BBOB_NOISY_SPECS
+}

--- a/src/bbob_jax/_src/bounds.py
+++ b/src/bbob_jax/_src/bounds.py
@@ -1,4 +1,5 @@
-"""Search-space bounds for BBOB, CEC 2005 and CEC 2017 benchmarks.
+"""Search-space bounds for the BBOB, BBOB-noisy, CEC 2005 and
+CEC 2017 benchmarks.
 
 Derived from the :class:`~bbob_jax._src.spec.FunctionSpec`
 table in ``spec.py``.
@@ -10,6 +11,7 @@ table in ``spec.py``.
 # Local
 from bbob_jax._src.spec import (
     BBOB_BOUNDS,
+    BBOB_NOISY_SPECS,
     BBOB_SPECS,
     CEC2005_SPECS,
     CEC2017_SPECS,
@@ -22,10 +24,20 @@ __credits__ = ["Martin van der Schelling"]
 __status__ = "Stable"
 # =============================================================================
 
-__all__ = ["BBOB_BOUNDS", "bbob_bounds", "cec2005_bounds", "cec2017_bounds"]
+__all__ = [
+    "BBOB_BOUNDS",
+    "bbob_bounds",
+    "bbob_noisy_bounds",
+    "cec2005_bounds",
+    "cec2017_bounds",
+]
 
 bbob_bounds: dict[str, tuple[float, float]] = {
     s.name: s.bounds for s in BBOB_SPECS
+}
+
+bbob_noisy_bounds: dict[str, tuple[float, float]] = {
+    s.name: s.bounds for s in BBOB_NOISY_SPECS
 }
 
 cec2005_bounds: dict[str, tuple[float, float]] = {

--- a/src/bbob_jax/_src/cec2005.py
+++ b/src/bbob_jax/_src/cec2005.py
@@ -186,6 +186,37 @@ def f4(
     return base * (1 + 0.4 * jr.normal(key, shape=())) + f_opt
 
 
+def f4_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+) -> jax.Array:
+    """Undisturbed value of :func:`f4` (noise stripped).
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Optimal point.
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Rotation matrix (unused).
+    Q : jax.Array
+        Second rotation matrix (unused).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value(s).
+    """
+    z = x - x_opt
+    return jnp.sum(jnp.cumsum(z) ** 2) + f_opt
+
+
 def f5(
     x: jax.Array,
     x_opt: jax.Array,
@@ -1328,6 +1359,68 @@ def f24(
     """
     fns = _composition4_fns()
     fns[-1] = lambda z: _sphere_noisy_base(z, key)
+    sigma = jnp.full(10, 2.0)
+    lambda_ = jnp.array(
+        [
+            10,
+            5 / 20,
+            1,
+            5 / 32,
+            1,
+            5 / 100,
+            5 / 50,
+            1,
+            5 / 100,
+            5 / 100,
+        ]
+    )
+    bias = _composition_bias()
+    return (
+        hybrid_composition(
+            x, fns, sigma, lambda_, bias, x_opt, R, _f_max=_f_max
+        )
+        + f_opt
+    )
+
+
+def f24_true(
+    x: jax.Array,
+    x_opt: jax.Array,
+    f_opt: jax.Array,
+    R: jax.Array,
+    Q: jax.Array,
+    _f_max: jax.Array | None = None,
+) -> jax.Array:
+    """Undisturbed value of :func:`f24` (noise stripped).
+
+    Identical composition with the 10th component's noise
+    removed: a plain sphere instead of the noisy sphere. Also
+    the undisturbed value of :func:`f25`, which forwards to
+    :func:`f24`.
+
+    Parameters
+    ----------
+    x : jax.Array
+        Input array of shape (..., ndim).
+    x_opt : jax.Array
+        Matrix of component optima of shape (10, ndim).
+    f_opt : jax.Array
+        Optimal function value offset.
+    R : jax.Array
+        Stack of rotation matrices of shape (10, ndim, ndim).
+    Q : jax.Array
+        Unused.
+    _f_max : jax.Array, optional
+        Precomputed reference normalization values for composition
+        components, of shape (num_components,).
+
+    Returns
+    -------
+    jax.Array
+        Undisturbed function value(s).
+    """
+    fns = _composition4_fns()
+    fns[-1] = _sphere_base
     sigma = jnp.full(10, 2.0)
     lambda_ = jnp.array(
         [

--- a/src/bbob_jax/_src/noise.py
+++ b/src/bbob_jax/_src/noise.py
@@ -1,0 +1,167 @@
+"""BBOB-noisy noise models: Gaussian, uniform and Cauchy.
+
+The three stochastic transforms of the BBOB-noisy suite
+(`f101`-`f130`), replicating the legacy COCO reference
+(``benchmarkshelper.c``: ``FGauss``, ``FUniform``, ``FCauchy``).
+Each model disturbs the *residual* above the optimum — the base
+function value before the boundary penalty and ``f_opt`` offset
+are added — and applies the noise gate: residuals below ``TOL``
+are returned undisturbed, everything else gets the disturbed
+value plus ``1.01 * TOL``. This guarantees ``fn(x_opt, key) ==
+f_opt`` exactly.
+
+The current COCO revival (``transform_obj_*_noise.c``) drops the
+gate and uses a linear boundary penalty; the legacy code and the
+published definition agree with each other, so legacy semantics
+are kept (code-wins rule, see ``docs/adr/0004``).
+"""
+
+#                                                                       Modules
+# =============================================================================
+
+# Third-party
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from jaxtyping import PRNGKeyArray
+
+#                                                          Authorship & Credits
+# =============================================================================
+__author__ = "Martin van der Schelling (M.P.vanderSchelling@tudelft.nl)"
+__credits__ = ["Martin van der Schelling"]
+__status__ = "Stable"
+# =============================================================================
+
+TOL = 1e-8
+"""Noise gate threshold: residuals below this stay undisturbed."""
+
+
+def _gate(f_true: jax.Array, f_val: jax.Array) -> jax.Array:
+    """Apply the noise gate (final adjustment) to a disturbed value.
+
+    Parameters
+    ----------
+    f_true : jax.Array
+        Undisturbed residual (base value above the optimum).
+    f_val : jax.Array
+        Disturbed residual, before the ``1.01 * TOL`` shift.
+
+    Returns
+    -------
+    jax.Array
+        ``f_true`` where ``f_true < TOL``, else
+        ``f_val + 1.01 * TOL``.
+    """
+    return jnp.where(f_true < TOL, f_true, f_val + 1.01 * TOL)
+
+
+def _gated_residual(f_true: jax.Array) -> jax.Array:
+    """Clamp the residual used inside noise formulas to ``TOL``.
+
+    Where ``f_true < TOL`` the disturbed branch of the gate is
+    unselected, but ``jnp.where`` still differentiates through
+    it; clamping keeps that dead branch free of ``0 ** x`` /
+    division blow-ups that would poison gradients with NaNs.
+    """
+    return jnp.maximum(f_true, TOL)
+
+
+def gauss_noise(
+    f_true: jax.Array, key: PRNGKeyArray, beta: float
+) -> jax.Array:
+    """Multiplicative Gaussian (log-normal) noise.
+
+    ``f * exp(beta * N(0, 1))``, gated. Moderate severity uses
+    ``beta = 0.01``, severe uses ``beta = 1``.
+
+    Parameters
+    ----------
+    f_true : jax.Array
+        Undisturbed residual above the optimum.
+    key : PRNGKeyArray
+        JAX random key (one normal draw).
+    beta : float
+        Noise strength.
+
+    Returns
+    -------
+    jax.Array
+        Disturbed residual.
+    """
+    f_val = _gated_residual(f_true) * jnp.exp(beta * jr.normal(key, shape=()))
+    return _gate(f_true, f_val)
+
+
+def uniform_noise(
+    f_true: jax.Array, key: PRNGKeyArray, alpha: float, beta: float
+) -> jax.Array:
+    """Multiplicative uniform noise.
+
+    ``U1**beta * f * max(1, (1e9 / (f + 1e-99)) ** (alpha * U2))``,
+    gated. Moderate severity uses ``alpha = 0.01 * (0.49 + 1/D)``
+    and ``beta = 0.01``; severe uses ``alpha = 0.49 + 1/D`` and
+    ``beta = 1``.
+
+    Parameters
+    ----------
+    f_true : jax.Array
+        Undisturbed residual above the optimum.
+    key : PRNGKeyArray
+        JAX random key (two uniform draws).
+    alpha : float
+        Exponent scale of the amplification factor.
+    beta : float
+        Exponent of the attenuation factor.
+
+    Returns
+    -------
+    jax.Array
+        Disturbed residual.
+    """
+    key1, key2 = jr.split(key)
+    u1 = jr.uniform(key1, shape=())
+    u2 = jr.uniform(key2, shape=())
+    f_safe = _gated_residual(f_true)
+    amplification = jnp.maximum(1.0, (1e9 / (f_safe + 1e-99)) ** (alpha * u2))
+    f_val = u1**beta * f_safe * amplification
+    return _gate(f_true, f_val)
+
+
+def cauchy_noise(
+    f_true: jax.Array, key: PRNGKeyArray, alpha: float, p: float
+) -> jax.Array:
+    """Additive, seldom-triggered Cauchy noise.
+
+    ``f + alpha * max(0, 1e3 + I_{U < p} * N1 / |N2 + 1e-199|)``,
+    gated. The ratio of two independent normals is standard
+    Cauchy distributed, so with probability ``p`` a heavy-tailed
+    outlier is added on top of the constant ``alpha * 1e3``
+    offset. Moderate severity uses ``alpha = 0.01, p = 0.05``;
+    severe uses ``alpha = 1, p = 0.2``.
+
+    Parameters
+    ----------
+    f_true : jax.Array
+        Undisturbed residual above the optimum.
+    key : PRNGKeyArray
+        JAX random key (two normal draws, one uniform draw).
+    alpha : float
+        Noise scale.
+    p : float
+        Probability of drawing the Cauchy outlier.
+
+    Returns
+    -------
+    jax.Array
+        Disturbed residual.
+    """
+    key1, key2, key3 = jr.split(key, 3)
+    n1 = jr.normal(key1, shape=())
+    n2 = jr.normal(key2, shape=())
+    u = jr.uniform(key3, shape=())
+    cauchy = n1 / jnp.abs(n2 + 1e-199)
+    indicator = (u < p).astype(cauchy.dtype)
+    f_val = _gated_residual(f_true) + alpha * jnp.maximum(
+        0.0, 1e3 + indicator * cauchy
+    )
+    return _gate(f_true, f_val)

--- a/src/bbob_jax/_src/problem.py
+++ b/src/bbob_jax/_src/problem.py
@@ -16,6 +16,7 @@ from typing import NamedTuple
 
 # Third-party
 import jax
+from jax.tree_util import Partial
 from jaxtyping import PRNGKeyArray
 
 # Local
@@ -60,6 +61,12 @@ class Problem(NamedTuple):
     min_ndim : int
         Smallest ``ndim`` the function is defined for;
         construction raises ``ValueError`` below it.
+    fn_true : Callable
+        Undisturbed function, called as ``fn_true(x)``. For
+        noisy functions this is the noise-free value (base +
+        boundary penalty + ``f_opt``) with the same bound
+        instance parameters as ``fn``; for noise-free functions
+        it is ``fn`` itself.
     """
 
     name: str
@@ -70,6 +77,7 @@ class Problem(NamedTuple):
     tags: dict[str, bool]
     noisy: bool
     min_ndim: int
+    fn_true: Callable[..., jax.Array]
 
 
 def problem(
@@ -114,6 +122,7 @@ def problem(
     fn, f_opt = spec.maker(ndim=ndim, key=key, deterministic=deterministic)
     kw = _partial_keywords(fn)
     x_opt = spec.x_opt_from(kw, ndim)
+    fn_true = Partial(spec.true_fn, **kw) if spec.true_fn is not None else fn
     return Problem(
         name=spec.name,
         fn=fn,
@@ -123,4 +132,5 @@ def problem(
         tags=dict(spec.tags),
         noisy=spec.tags.get("noise", False),
         min_ndim=spec.min_ndim,
+        fn_true=fn_true,
     )

--- a/src/bbob_jax/_src/registry.py
+++ b/src/bbob_jax/_src/registry.py
@@ -1,6 +1,6 @@
-"""Registries for the BBOB, CEC 2005 and CEC 2017 benchmark functions.
+"""Registries for the BBOB, BBOB-noisy, CEC 2005 and CEC 2017 benchmarks.
 
-The six registry dicts are derived views of the
+The eight registry dicts are derived views of the
 :class:`~bbob_jax._src.spec.FunctionSpec` table in ``spec.py``:
 the randomized registries call each spec's maker as-is, the
 ``*_original`` registries bind ``deterministic=True`` (zero
@@ -25,7 +25,12 @@ from jaxtyping import PRNGKeyArray
 
 # Local
 from bbob_jax._src.factories import BBOBFn
-from bbob_jax._src.spec import BBOB_SPECS, CEC2005_SPECS, CEC2017_SPECS
+from bbob_jax._src.spec import (
+    BBOB_NOISY_SPECS,
+    BBOB_SPECS,
+    CEC2005_SPECS,
+    CEC2017_SPECS,
+)
 
 #                                                          Authorship & Credits
 # =============================================================================
@@ -40,6 +45,14 @@ registry: dict[str, Callable[[int, PRNGKeyArray], BBOBFn]] = {
 
 registry_original: dict[str, Callable[[int], BBOBFn]] = {
     s.name: Partial(s.maker, deterministic=True) for s in BBOB_SPECS
+}
+
+bbob_noisy_registry: dict[str, Callable] = {
+    s.name: s.maker for s in BBOB_NOISY_SPECS
+}
+
+bbob_noisy_registry_original: dict[str, Callable] = {
+    s.name: Partial(s.maker, deterministic=True) for s in BBOB_NOISY_SPECS
 }
 
 cec2005_registry: dict[str, Callable] = {

--- a/src/bbob_jax/_src/spec.py
+++ b/src/bbob_jax/_src/spec.py
@@ -24,7 +24,7 @@ import jax
 import jax.numpy as jnp
 from jax.tree_util import Partial
 
-from bbob_jax._src import cec2017
+from bbob_jax._src import bbob_noisy, cec2017
 
 # Local
 from bbob_jax._src.bbob import (
@@ -61,6 +61,7 @@ from bbob_jax._src.cec2005 import (
     f2,
     f3,
     f4,
+    f4_true,
     f5,
     f6,
     f7,
@@ -81,6 +82,7 @@ from bbob_jax._src.cec2005 import (
     f22,
     f23,
     f24,
+    f24_true,
     f25,
 )
 from bbob_jax._src.factories import (
@@ -183,6 +185,30 @@ def _bbob_tags(*, separable: bool, unimodal: bool) -> dict[str, bool]:
     return {"separable": separable, "unimodal": unimodal}
 
 
+def _bbob_noisy_tags(
+    *, separable: bool, unimodal: bool, model: str, severe: bool
+) -> dict[str, bool]:
+    """BBOB-noisy tag schema.
+
+    ``separable`` and ``unimodal`` describe the undisturbed base
+    function, mirroring the noiseless suite's labels. Exactly one
+    of the three noise-model flags is True. ``severe`` is False
+    for the moderate-noise group f101-f106. ``noise`` is True on
+    every row: the call signature is ``fn(x, key)``.
+    """
+    if model not in ("gauss", "uniform", "cauchy"):
+        raise ValueError(f"Unknown noise model: {model}")
+    return {
+        "separable": separable,
+        "unimodal": unimodal,
+        "gaussian_noise": model == "gauss",
+        "uniform_noise": model == "uniform",
+        "cauchy_noise": model == "cauchy",
+        "severe": severe,
+        "noise": True,
+    }
+
+
 def _cec_tags(
     *,
     unimodal: bool = False,
@@ -252,8 +278,8 @@ class FunctionSpec(NamedTuple):
     name : str
         Registry key of the function.
     suite : str
-        Benchmark suite, ``"bbob"``, ``"cec2005"`` or
-        ``"cec2017"``.
+        Benchmark suite, ``"bbob"``, ``"bbob_noisy"``,
+        ``"cec2005"`` or ``"cec2017"``.
     maker : Callable
         Factory constructing a problem instance. Called as
         ``maker(ndim=..., key=..., deterministic=...)`` and
@@ -269,6 +295,11 @@ class FunctionSpec(NamedTuple):
         Smallest ``ndim`` the function is defined for. Makers
         raise ``ValueError`` below it (e.g. CEC 2017 hybrids
         need one dimension per subcomponent kernel).
+    true_fn : Callable or None
+        For noisy functions, the undisturbed implementation with
+        the same bound-parameter signature minus ``key``;
+        ``problem()`` binds it as ``Problem.fn_true``. None for
+        noise-free functions (``fn_true`` is then ``fn`` itself).
     """
 
     name: str
@@ -278,6 +309,7 @@ class FunctionSpec(NamedTuple):
     bounds: tuple[float, float]
     x_opt_from: Callable[[dict[str, Any], int], jax.Array] = _default_x_opt
     min_ndim: int = 1
+    true_fn: Callable[..., jax.Array] | None = None
 
 
 #                                                                   BBOB table
@@ -490,6 +522,355 @@ BBOB_SPECS: tuple[FunctionSpec, ...] = (
     ),
 )
 
+#                                                             BBOB-noisy table
+# =============================================================================
+# f101-f130: eight base landscapes x three noise models (Gaussian, uniform,
+# Cauchy — always in that order within a triple), moderate severity for
+# f101-f106 and severe for f107-f130. ``true_fn`` is the shared undisturbed
+# base of each triple.
+
+BBOB_NOISY_SPECS: tuple[FunctionSpec, ...] = (
+    FunctionSpec(
+        name="bbob_noisy_f101",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f101),
+        tags=_bbob_noisy_tags(
+            separable=True, unimodal=True, model="gauss", severe=False
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.sphere_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f102",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f102),
+        tags=_bbob_noisy_tags(
+            separable=True, unimodal=True, model="uniform", severe=False
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.sphere_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f103",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f103),
+        tags=_bbob_noisy_tags(
+            separable=True, unimodal=True, model="cauchy", severe=False
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.sphere_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f104",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f104),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="gauss", severe=False
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f105",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f105),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="uniform", severe=False
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f106",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f106),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="cauchy", severe=False
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f107",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f107),
+        tags=_bbob_noisy_tags(
+            separable=True, unimodal=True, model="gauss", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.sphere_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f108",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f108),
+        tags=_bbob_noisy_tags(
+            separable=True, unimodal=True, model="uniform", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.sphere_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f109",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f109),
+        tags=_bbob_noisy_tags(
+            separable=True, unimodal=True, model="cauchy", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.sphere_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f110",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f110),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="gauss", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f111",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f111),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="uniform", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f112",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f112),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="cauchy", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f113",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_with_mat, fn=bbob_noisy.f113, alpha=10.0, order="LR"
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="gauss", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.step_ellipsoid_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f114",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_with_mat, fn=bbob_noisy.f114, alpha=10.0, order="LR"
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="uniform", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.step_ellipsoid_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f115",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_with_mat, fn=bbob_noisy.f115, alpha=10.0, order="LR"
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="cauchy", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.step_ellipsoid_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f116",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f116),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="gauss", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.ellipsoid_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f117",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f117),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="uniform", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.ellipsoid_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f118",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f118),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="cauchy", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.ellipsoid_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f119",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f119),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="gauss", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.different_powers_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f120",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f120),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="uniform", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.different_powers_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f121",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f121),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=True, model="cauchy", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.different_powers_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f122",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_with_mat, fn=bbob_noisy.f122, alpha=10.0, order="LQ"
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="gauss", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.schaffer_f7_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f123",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_with_mat, fn=bbob_noisy.f123, alpha=10.0, order="LQ"
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="uniform", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.schaffer_f7_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f124",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_with_mat, fn=bbob_noisy.f124, alpha=10.0, order="LQ"
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="cauchy", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.schaffer_f7_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f125",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f125),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="gauss", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        x_opt_from=_griewank_rosenbrock_x_opt,
+        true_fn=bbob_noisy.griewank_rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f126",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f126),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="uniform", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        x_opt_from=_griewank_rosenbrock_x_opt,
+        true_fn=bbob_noisy.griewank_rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f127",
+        suite="bbob_noisy",
+        maker=Partial(make_bbob, fn=bbob_noisy.f127),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="cauchy", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        x_opt_from=_griewank_rosenbrock_x_opt,
+        true_fn=bbob_noisy.griewank_rosenbrock_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f128",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_gallagher,
+            fn=bbob_noisy.f128,
+            num_peaks=101,
+            w_divisor=99,
+            alpha_first=1000.0,
+            y_minval=-5.0,
+            y_maxval=5.0,
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="gauss", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.gallagher_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f129",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_gallagher,
+            fn=bbob_noisy.f129,
+            num_peaks=101,
+            w_divisor=99,
+            alpha_first=1000.0,
+            y_minval=-5.0,
+            y_maxval=5.0,
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="uniform", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.gallagher_true,
+    ),
+    FunctionSpec(
+        name="bbob_noisy_f130",
+        suite="bbob_noisy",
+        maker=Partial(
+            _make_gallagher,
+            fn=bbob_noisy.f130,
+            num_peaks=101,
+            w_divisor=99,
+            alpha_first=1000.0,
+            y_minval=-5.0,
+            y_maxval=5.0,
+        ),
+        tags=_bbob_noisy_tags(
+            separable=False, unimodal=False, model="cauchy", severe=True
+        ),
+        bounds=BBOB_BOUNDS,
+        true_fn=bbob_noisy.gallagher_true,
+    ),
+)
+
 #                                                               CEC 2005 table
 # =============================================================================
 
@@ -601,6 +982,7 @@ CEC2005_SPECS: tuple[FunctionSpec, ...] = (
         ),
         tags=_cec_tags(unimodal=True, noise=True),
         bounds=(-100.0, 100.0),
+        true_fn=f4_true,
     ),
     FunctionSpec(
         name="f5",
@@ -751,6 +1133,7 @@ CEC2005_SPECS: tuple[FunctionSpec, ...] = (
         tags=_cec_tags(composition=True, rotated=True, noise=True),
         bounds=(-5.0, 5.0),
         x_opt_from=_first_component_x_opt,
+        true_fn=f16,
     ),
     FunctionSpec(
         name="f18",
@@ -894,6 +1277,7 @@ CEC2005_SPECS: tuple[FunctionSpec, ...] = (
         ),
         bounds=(-5.0, 5.0),
         x_opt_from=_first_component_x_opt,
+        true_fn=f24_true,
     ),
     FunctionSpec(
         name="f25",
@@ -925,6 +1309,7 @@ CEC2005_SPECS: tuple[FunctionSpec, ...] = (
         ),
         bounds=(2.0, 5.0),
         x_opt_from=_first_component_x_opt,
+        true_fn=f24_true,
     ),
 )
 
@@ -1211,7 +1596,9 @@ CEC2017_SPECS: tuple[FunctionSpec, ...] = (
 #                                                                Derived views
 # =============================================================================
 
-SPECS: tuple[FunctionSpec, ...] = BBOB_SPECS + CEC2005_SPECS + CEC2017_SPECS
+SPECS: tuple[FunctionSpec, ...] = (
+    BBOB_SPECS + BBOB_NOISY_SPECS + CEC2005_SPECS + CEC2017_SPECS
+)
 SPEC_BY_NAME: dict[str, FunctionSpec] = {s.name: s for s in SPECS}
 
 if len(SPEC_BY_NAME) != len(SPECS):

--- a/src/bbob_jax/bounds.py
+++ b/src/bbob_jax/bounds.py
@@ -1,3 +1,13 @@
-from ._src.bounds import bbob_bounds, cec2005_bounds, cec2017_bounds
+from ._src.bounds import (
+    bbob_bounds,
+    bbob_noisy_bounds,
+    cec2005_bounds,
+    cec2017_bounds,
+)
 
-__all__ = ["bbob_bounds", "cec2005_bounds", "cec2017_bounds"]
+__all__ = [
+    "bbob_bounds",
+    "bbob_noisy_bounds",
+    "cec2005_bounds",
+    "cec2017_bounds",
+]

--- a/tests/test_bbob_noisy.py
+++ b/tests/test_bbob_noisy.py
@@ -1,0 +1,270 @@
+"""Tests for the BBOB-noisy suite (f101-f130).
+
+JAX-compatibility battery (jit, vmap, grad, NaN propagation)
+mirroring the other suites, plus noise-specific checks: the
+pinned-draw formula tests re-derive every function's disturbed
+value from its ``fn_true`` residual and the noise-model formulas
+(same key-split protocol), and the statistical tests pin the
+three models' distributions with a fixed key set (fully
+deterministic, no flakiness). The deterministic undisturbed path
+is additionally cross-checked against the compiled legacy C
+reference by ``scripts/crosscheck_bbob_noisy.py`` (not in CI).
+"""
+
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import pytest
+
+from bbob_jax import (
+    bbob_noisy_function_characteristics,
+    bbob_noisy_registry,
+    bbob_noisy_registry_original,
+    problem,
+)
+from bbob_jax._src.mesh import _create_mesh
+from bbob_jax._src.noise import TOL
+
+pytest_noisy = [
+    pytest.param(name, fn, id=f"bbob_noisy_registry::{name}")
+    for name, fn in bbob_noisy_registry.items()
+]
+pytest_noisy_original = [
+    pytest.param(name, fn, id=f"bbob_noisy_registry_original::{name}")
+    for name, fn in bbob_noisy_registry_original.items()
+]
+all_noisy = pytest_noisy + pytest_noisy_original
+
+NAMES = list(bbob_noisy_registry.keys())
+
+dimensions = [2, 3, 5, 10, 20]
+
+
+def _noise_params(name: str, ndim: int) -> tuple[str, dict]:
+    """Model name and parameters implied by a function's tags."""
+    tags = bbob_noisy_function_characteristics[name]
+    severe = tags["severe"]
+    if tags["gaussian_noise"]:
+        return "gauss", {"beta": 1.0 if severe else 0.01}
+    if tags["uniform_noise"]:
+        alpha = 0.49 + 1.0 / ndim
+        if not severe:
+            alpha *= 0.01
+        return "uniform", {"alpha": alpha, "beta": 1.0 if severe else 0.01}
+    return "cauchy", (
+        {"alpha": 1.0, "p": 0.2} if severe else {"alpha": 0.01, "p": 0.05}
+    )
+
+
+def _expected_disturbed(
+    model: str, params: dict, residual: jax.Array, key: jax.Array
+) -> jax.Array:
+    """Reference reimplementation of the noise models (gate included)."""
+    if model == "gauss":
+        f_val = residual * jnp.exp(params["beta"] * jr.normal(key))
+    elif model == "uniform":
+        key1, key2 = jr.split(key)
+        u1, u2 = jr.uniform(key1), jr.uniform(key2)
+        f_val = (
+            u1 ** params["beta"]
+            * residual
+            * jnp.maximum(
+                1.0, (1e9 / (residual + 1e-99)) ** (params["alpha"] * u2)
+            )
+        )
+    else:
+        key1, key2, key3 = jr.split(key, 3)
+        n1, n2 = jr.normal(key1), jr.normal(key2)
+        u = jr.uniform(key3)
+        f_val = residual + params["alpha"] * jnp.maximum(
+            0.0, 1e3 + (u < params["p"]) * n1 / jnp.abs(n2 + 1e-199)
+        )
+    return jnp.where(residual < TOL, residual, f_val + 1.01 * TOL)
+
+
+#                                                     JAX-compatibility battery
+# =============================================================================
+
+
+@pytest.mark.parametrize("name,fn", all_noisy)
+@pytest.mark.parametrize("dim", dimensions)
+def test_function_output(name, fn, dim):
+    key = jr.key(0)
+    x = jr.uniform(key, shape=(dim,), minval=-5.0, maxval=5.0)
+    fn_func, _ = fn(ndim=dim, key=key)
+    y = fn_func(x, jr.key(42))
+    assert jnp.isfinite(y), f"{name} returned non-finite value: {y}"
+    assert jnp.ndim(y) == 0, f"{name} did not return scalar: {y.shape}"
+
+
+@pytest.mark.parametrize("name,fn", all_noisy)
+@pytest.mark.parametrize("dim", dimensions)
+def test_function_output_jit(name, fn, dim):
+    key = jr.key(0)
+    x = jr.uniform(key, shape=(dim,), minval=-5.0, maxval=5.0)
+    fn_func, _ = fn(ndim=dim, key=key)
+    y = jax.jit(fn_func)(x, jr.key(42))
+    assert jnp.isfinite(y), f"{name} JIT returned non-finite: {y}"
+    assert jnp.ndim(y) == 0
+
+
+@pytest.mark.parametrize("name,fn", pytest_noisy)
+@pytest.mark.parametrize("dim", [2])
+@pytest.mark.parametrize("seed", [1, 2])
+def test_function_vmap(name, fn, dim, seed):
+    key = jr.key(seed)
+    fn_func, _ = fn(ndim=dim, key=key)
+    _, _, Z = _create_mesh(
+        lambda x: fn_func(x, jr.key(42)), bounds=(-5.0, 5.0), px=50
+    )
+    assert jnp.all(jnp.isfinite(Z)), f"{name} vmap returned non-finite"
+
+
+@pytest.mark.parametrize("name,fn", pytest_noisy)
+@pytest.mark.parametrize("dim", dimensions)
+@pytest.mark.parametrize("seed", [1, 2])
+def test_function_grad(name, fn, dim, seed):
+    key = jr.key(seed)
+    key_x, key_fn = jr.split(key)
+    x = jr.uniform(key_x, shape=(10, dim), minval=-5.0, maxval=5.0)
+    fn_func, _ = fn(ndim=dim, key=key_fn)
+    grad_fn = jax.grad(lambda x: fn_func(x, jr.key(42)))
+    grad_value = jax.vmap(grad_fn)(x)
+    assert grad_value.shape == x.shape
+    assert jnp.all(jnp.isfinite(grad_value)), (
+        f"{name} grad returned non-finite"
+    )
+
+
+@pytest.mark.parametrize("name,fn", all_noisy)
+def test_nan_propagation(name, fn):
+    key = jr.key(0)
+    fn_func, _ = fn(ndim=3, key=key)
+    y = fn_func(jnp.full(3, jnp.nan), jr.key(42))
+    assert jnp.isnan(y), f"{name} did not propagate NaN: {y}"
+
+
+#                                                          Noise-specific tests
+# =============================================================================
+
+
+@pytest.mark.parametrize("name", NAMES)
+@pytest.mark.parametrize("seed", [0, 1])
+def test_key_determinism(name, seed):
+    """Same key -> same value; a key batch is not constant."""
+    p = problem(name, ndim=3, key=jr.key(seed))
+    x = jr.uniform(jr.key(9), shape=(3,), minval=-4.0, maxval=4.0)
+    v1 = p.fn(x, jr.key(5))
+    v2 = p.fn(x, jr.key(5))
+    assert jnp.array_equal(v1, v2)
+    # seldom Cauchy noise adds a constant offset for most keys, so
+    # uniqueness needs a batch, not a pair (256 keys -> the outlier
+    # branch triggers with overwhelming probability).
+    keys = jr.split(jr.key(6), 256)
+    values = jax.vmap(lambda k: p.fn(x, k))(keys)
+    assert jnp.unique(values).size > 1, f"{name} looks noise-free"
+
+
+@pytest.mark.parametrize("name", NAMES)
+@pytest.mark.parametrize("dim", [2, 5])
+def test_disturbed_value_matches_noise_formula(name, dim):
+    """fn(x, key) == noise_model(fn_true residual) + penalty + f_opt.
+
+    Re-derives the disturbed value from the undisturbed residual
+    with the documented formulas and key-split protocol — pins
+    the noise wiring (model choice, severity parameters, gate,
+    what the noise does and does not disturb) for all 30
+    functions.
+    """
+    p = problem(name, ndim=dim, key=jr.key(3))
+    # in-bounds x: no boundary penalty term
+    x = jr.uniform(jr.key(8), shape=(dim,), minval=-4.0, maxval=4.0)
+    residual = p.fn_true(x) - p.f_opt
+    model, params = _noise_params(name, dim)
+    key = jr.key(21)
+    expected = _expected_disturbed(model, params, residual, key) + p.f_opt
+    actual = p.fn(x, key)
+    # rtol 1e-5: the uniform model's (1e9/residual)**(alpha*u2) amplifies
+    # float32 last-ulp differences in the residual to ~1e-6 relative.
+    assert jnp.allclose(actual, expected, rtol=1e-5), (
+        f"{name}: expected {expected}, got {actual}"
+    )
+
+
+def test_penalty_outside_noise():
+    """The x100 boundary penalty is added outside the noise.
+
+    On the sphere the residual is computable by hand, so both
+    the undisturbed and the disturbed value at an out-of-bounds
+    point can be checked exactly: the penalty term appears
+    undamped in both."""
+    p = problem("bbob_noisy_f107", ndim=3, key=jr.key(2))
+    x_out = jnp.array([6.0, -7.0, 0.5])
+    excess = jnp.sum(jnp.maximum(jnp.abs(x_out) - 5.0, 0.0) ** 2)
+    residual = jnp.sum((x_out - p.x_opt) ** 2)
+    assert jnp.allclose(
+        p.fn_true(x_out), residual + 100.0 * excess + p.f_opt, rtol=1e-6
+    )
+    key = jr.key(4)
+    disturbed = _expected_disturbed("gauss", {"beta": 1.0}, residual, key)
+    assert jnp.allclose(
+        p.fn(x_out, key),
+        disturbed + 100.0 * excess + p.f_opt,
+        rtol=1e-6,
+    )
+
+
+def test_gate_returns_undisturbed_below_tol():
+    """Residuals below TOL bypass the noise entirely."""
+    p = problem("bbob_noisy_f107", ndim=4, key=jr.key(0))
+    keys = jr.split(jr.key(1), 32)
+    values = jax.vmap(lambda k: p.fn(p.x_opt, k))(keys)
+    assert jnp.all(values == p.f_opt)
+
+
+def test_gaussian_noise_statistics():
+    """f107: log((fval - f_opt - 1.01e-8) / residual) ~ N(0, 1)."""
+    p = problem("bbob_noisy_f107", ndim=5, key=jr.key(0))
+    x = jr.uniform(jr.key(2), shape=(5,), minval=-4.0, maxval=4.0)
+    residual = p.fn_true(x) - p.f_opt
+    keys = jr.split(jr.key(3), 4096)
+    values = jax.vmap(lambda k: p.fn(x, k))(keys)
+    z = jnp.log((values - p.f_opt - 1.01 * TOL) / residual)
+    assert jnp.abs(jnp.mean(z)) < 0.1
+    assert jnp.abs(jnp.std(z) - 1.0) < 0.1
+
+
+def test_cauchy_noise_statistics():
+    """f109: the Cauchy outlier triggers with probability p = 0.2."""
+    p = problem("bbob_noisy_f109", ndim=5, key=jr.key(0))
+    x = jr.uniform(jr.key(2), shape=(5,), minval=-4.0, maxval=4.0)
+    residual = p.fn_true(x) - p.f_opt
+    keys = jr.split(jr.key(3), 4096)
+    values = jax.vmap(lambda k: p.fn(x, k))(keys)
+    extra = values - p.f_opt - 1.01 * TOL - residual
+    # non-outlier draws add exactly alpha * 1e3
+    outlier_frac = jnp.mean(jnp.abs(extra - 1e3) > 1e-2)
+    assert 0.15 < outlier_frac < 0.25
+
+
+def test_uniform_noise_statistics():
+    """f108: support and amplification of the uniform model."""
+    p = problem("bbob_noisy_f108", ndim=5, key=jr.key(0))
+    x = jr.uniform(jr.key(2), shape=(5,), minval=-4.0, maxval=4.0)
+    residual = p.fn_true(x) - p.f_opt
+    keys = jr.split(jr.key(3), 4096)
+    values = jax.vmap(lambda k: p.fn(x, k))(keys)
+    disturbed = values - p.f_opt - 1.01 * TOL
+    alpha = 0.49 + 1.0 / 5
+    upper = residual * (1e9 / residual) ** alpha
+    assert jnp.all(disturbed > 0.0)
+    assert jnp.all(disturbed <= upper * 1.001)
+    # amplification dominates attenuation away from the optimum
+    assert jnp.mean(disturbed > residual) > 0.5
+
+
+def test_deterministic_instances_are_zero_at_origin_optimum():
+    for name in ("bbob_noisy_f101", "bbob_noisy_f113", "bbob_noisy_f128"):
+        p = problem(name, ndim=3, deterministic=True)
+        assert p.fn(p.x_opt, jr.key(0)) == 0.0
+        assert p.fn_true(p.x_opt) == 0.0

--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -10,6 +10,10 @@ import pytest
 
 from bbob_jax import (
     bbob_bounds,
+    bbob_noisy_bounds,
+    bbob_noisy_function_characteristics,
+    bbob_noisy_registry,
+    bbob_noisy_registry_original,
     cec2005_bounds,
     cec2005_function_characteristics,
     cec2005_registry,
@@ -24,6 +28,15 @@ from bbob_jax import (
 )
 
 BBOB_TAG_KEYS = {"separable", "unimodal"}
+BBOB_NOISY_TAG_KEYS = {
+    "separable",
+    "unimodal",
+    "gaussian_noise",
+    "uniform_noise",
+    "cauchy_noise",
+    "severe",
+    "noise",
+}
 CEC_TAG_KEYS = {
     "unimodal",
     "multimodal",
@@ -49,6 +62,18 @@ def test_bbob_key_sets_are_identical():
     assert set(bbob_bounds.keys()) == names
 
 
+def test_bbob_noisy_key_sets_are_identical():
+    names = set(bbob_noisy_registry.keys())
+    assert set(bbob_noisy_registry_original.keys()) == names
+    assert set(bbob_noisy_function_characteristics.keys()) == names
+    assert set(bbob_noisy_bounds.keys()) == names
+
+
+def test_bbob_noisy_names_cover_f101_to_f130():
+    expected = {f"bbob_noisy_f{i}" for i in range(101, 131)}
+    assert set(bbob_noisy_registry.keys()) == expected
+
+
 def test_cec2005_key_sets_are_identical():
     names = set(cec2005_registry.keys())
     assert set(cec2005_registry_original.keys()) == names
@@ -67,12 +92,16 @@ def test_suites_do_not_overlap():
     assert set(registry.keys()).isdisjoint(cec2005_registry.keys())
     assert set(registry.keys()).isdisjoint(cec2017_registry.keys())
     assert set(cec2005_registry.keys()).isdisjoint(cec2017_registry.keys())
+    assert set(bbob_noisy_registry.keys()).isdisjoint(registry.keys())
+    assert set(bbob_noisy_registry.keys()).isdisjoint(cec2005_registry.keys())
+    assert set(bbob_noisy_registry.keys()).isdisjoint(cec2017_registry.keys())
 
 
 @pytest.mark.parametrize(
     "tags_dict",
     [
         function_characteristics,
+        bbob_noisy_function_characteristics,
         cec2005_function_characteristics,
         cec2017_function_characteristics,
     ],
@@ -87,6 +116,26 @@ def test_bbob_tag_schema():
     for name, tags in function_characteristics.items():
         assert set(tags.keys()) == BBOB_TAG_KEYS, name
         assert all(isinstance(v, bool) for v in tags.values()), name
+
+
+def test_bbob_noisy_tag_schema():
+    for name, tags in bbob_noisy_function_characteristics.items():
+        assert set(tags.keys()) == BBOB_NOISY_TAG_KEYS, name
+        assert all(isinstance(v, bool) for v in tags.values()), name
+        assert tags["noise"], name
+        models = (
+            tags["gaussian_noise"],
+            tags["uniform_noise"],
+            tags["cauchy_noise"],
+        )
+        assert sum(models) == 1, name
+
+
+def test_bbob_noisy_severity_groups():
+    """f101-f106 are the moderate-noise group, f107-f130 severe."""
+    for name, tags in bbob_noisy_function_characteristics.items():
+        fid = int(name.removeprefix("bbob_noisy_f"))
+        assert tags["severe"] == (fid >= 107), name
 
 
 def test_cec2005_tag_schema():

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -15,6 +15,9 @@ import pytest
 from bbob_jax import (
     Problem,
     bbob_bounds,
+    bbob_noisy_bounds,
+    bbob_noisy_function_characteristics,
+    bbob_noisy_registry,
     cec2005_bounds,
     cec2005_function_characteristics,
     cec2005_registry,
@@ -27,6 +30,7 @@ from bbob_jax import (
 )
 
 BBOB_NAMES = list(registry.keys())
+BBOB_NOISY_NAMES = list(bbob_noisy_registry.keys())
 CEC_NAMES = list(cec2005_registry.keys())
 CEC2017_NAMES = list(cec2017_registry.keys())
 COMPOSITION_NAMES = [f"f{i}" for i in range(15, 26)]
@@ -170,6 +174,76 @@ def test_noisy_problems_take_key(name):
     assert p.noisy
     value = p.fn(jnp.zeros(3), jr.key(1))
     assert jnp.isfinite(value)
+
+
+@pytest.mark.parametrize("name", BBOB_NOISY_NAMES)
+def test_bbob_noisy_problem_fields_match_metadata_dicts(name):
+    p = problem(name, ndim=3, key=jr.key(0))
+    assert p.bounds == bbob_noisy_bounds[name]
+    assert p.tags == bbob_noisy_function_characteristics[name]
+    assert p.noisy is True
+
+
+@pytest.mark.parametrize("name", BBOB_NOISY_NAMES)
+@pytest.mark.parametrize("dim", [2, 5, 20])
+@pytest.mark.parametrize("deterministic", [False, True])
+def test_bbob_noisy_global_minimum_at_x_opt(name, dim, deterministic):
+    """fn(x_opt, key) == f_opt for every BBOB-noisy function.
+
+    Exact, not approximate: the residual at the optimum falls
+    below the 1e-8 noise gate, so the undisturbed value is
+    returned untouched.
+    """
+    p = problem(name, ndim=dim, key=jr.key(0), deterministic=deterministic)
+    result = p.fn(p.x_opt, jr.key(42))
+    assert jnp.isclose(result, p.f_opt, atol=1e-6), (
+        f"{name} dim={dim} deterministic={deterministic}: "
+        f"fn(x_opt, key)={result}, f_opt={p.f_opt}"
+    )
+    assert jnp.isclose(p.fn_true(p.x_opt), p.f_opt, atol=1e-6), name
+
+
+@pytest.mark.parametrize(
+    "name", ["sphere", "rastrigin", "f1", "f15", "cec2017_f1"]
+)
+def test_fn_true_is_fn_for_noise_free_problems(name):
+    ndim = 20 if name.startswith("cec2017") else 3
+    p = problem(name, ndim=ndim, key=jr.key(0))
+    assert p.fn_true is p.fn
+
+
+@pytest.mark.parametrize(
+    "name", BBOB_NOISY_NAMES + ["f4", "f17", "f24", "f25"]
+)
+def test_fn_true_is_deterministic_and_takes_no_key(name):
+    p = problem(name, ndim=3, key=jr.key(0))
+    assert p.fn_true is not p.fn
+    x = jr.uniform(jr.key(1), shape=(3,), minval=-1.0, maxval=1.0)
+    v1 = p.fn_true(x)
+    v2 = p.fn_true(x)
+    assert jnp.array_equal(v1, v2)
+    assert jnp.isfinite(v1)
+
+
+def test_cec2005_fn_true_strips_the_noise():
+    """f4: fn == fn_true residual scaled by the noise draw."""
+    p = problem("f4", ndim=4, key=jr.key(0))
+    x = jr.uniform(jr.key(1), shape=(4,), minval=-10.0, maxval=10.0)
+    key = jr.key(2)
+    base = p.fn_true(x) - p.f_opt
+    expected = base * (1 + 0.4 * jr.normal(key)) + p.f_opt
+    assert jnp.allclose(p.fn(x, key), expected, rtol=1e-6)
+
+
+def test_cec2005_f17_fn_true_is_f16():
+    """f17's undisturbed value is the f16 composition with f17's
+    own instance parameters."""
+    p = problem("f17", ndim=4, key=jr.key(0))
+    x = jr.uniform(jr.key(1), shape=(4,), minval=-5.0, maxval=5.0)
+    key = jr.key(2)
+    base = p.fn_true(x) - p.f_opt
+    expected = base * (1 + 0.4 * jnp.abs(jr.normal(key))) + p.f_opt
+    assert jnp.allclose(p.fn(x, key), expected, rtol=1e-6)
 
 
 @pytest.mark.parametrize("name", CEC2017_NAMES)


### PR DESCRIPTION
## Summary

Implements the 30 **BBOB-noisy** benchmark functions (f101–f130) as a new `bbob_noisy` suite, plus a new `Problem.fn_true` field exposing the undisturbed value of noisy functions across all suites.

- **Noise models** (`_src/noise.py`): Gaussian (multiplicative, log-normal), uniform (multiplicative) and Cauchy (additive, heavy-tailed), replicating the legacy COCO `benchmarkshelper.c` exactly — including the **noise gate**: residuals below 1e-8 bypass the noise, so `fn(x_opt, key) == f_opt` holds *exactly*.
- **Eight base landscapes** (`_src/bbob_noisy.py`): sphere, Rosenbrock (non-rotated), step ellipsoid, ellipsoid (condition 1e4), sum of different powers, Schaffer F7, Griewank–Rosenbrock, Gallagher 101 peaks. The ×100 boundary penalty applies to every function and — like `f_opt` — is added *outside* the noise. Suite-local `_tosz`/`_asym` helpers replicate the legacy transforms exactly (the shared `transforms.py` variants deviate for the noiseless suite and are pinned by ADR 0001).
- **`Problem.fn_true`**: undisturbed value with the same bound instance parameters; for noise-free functions it is `fn` itself, and CEC 2005 F4/F17/F24/F25 were retrofitted with undisturbed paths (`f4_true`, `f16` reuse, `f24_true`) so the field is never None. Wired via a new optional `FunctionSpec.true_fn` column.
- **Registry keys** `bbob_noisy_f101` … `bbob_noisy_f130` (suite-prefixed like `cec2017_fN`); tag schema `{separable, unimodal, gaussian_noise, uniform_noise, cauchy_noise, severe, noise}` with base-landscape labels mirroring the noiseless suite.
- `deterministic=True` keeps its established meaning: deterministic *instance parameters* — the noise stays stochastic.

## Verification

- `scripts/crosscheck_bbob_noisy.py` compiles the legacy `benchmarksnoisy.c`, extracts instance parameters from the official legacy Python (`bbobbenchmarks.py`, transposed from its row-vector convention), binds them into the bbob-jax implementations, and compares the undisturbed path point-for-point: **all 30 functions × D∈{2,5,10} × 2 instances, worst relative deviation ~4e-12** (Griewank–Rosenbrock accumulation-order noise; the official legacy Python deviates from the C by the same amount).
- The stochastic path is covered by pinned-draw formula re-derivation tests for all 30 functions and deterministic statistical tests per noise model (`tests/test_bbob_noisy.py`, 1146 tests).
- Note: the *current* COCO revival (`transform_obj_*_noise.c`) drops the noise gate and uses a linear boundary penalty; the legacy code agrees with the published definition on both points, so legacy semantics are kept (ADR 0004).

## Using the new API

Constructing and evaluating a noisy problem (optimizer's view):

```python
import jax.random as jr
from bbob_jax import problem

p = problem("bbob_noisy_f107", ndim=5, key=jr.key(0))  # sphere, severe Gaussian
p.noisy                       # True — call with a key
value = p.fn(x, jr.key(1))    # disturbed value, differs per key
p.fn(p.x_opt, jr.key(2))      # == p.f_opt exactly (noise gate)
```

Measuring true progress, COCO-style (harness view):

```python
f_true = p.fn_true(x)         # undisturbed: base + x100 penalty + f_opt
# fn_true is fn itself for noise-free functions, so this is uniform:
best_so_far = min(p.fn_true(x) for x in visited)
```

Filtering by noise characteristics (metadata view):

```python
from bbob_jax import bbob_noisy_function_characteristics, bbob_noisy_registry

cauchy_severe = [
    name for name, tags in bbob_noisy_function_characteristics.items()
    if tags["cauchy_noise"] and tags["severe"]
]
fn, f_opt = bbob_noisy_registry["bbob_noisy_f109"](ndim=5, key=jr.key(0))
```

## Docs

api.md section + usage-notebook section, CLAUDE.md, README, ADR 0004 (fn_true decision, verification split, COCO-revival divergence), CONTEXT.md glossary (suite vocabulary: disturbed/undisturbed value, noise gate, severity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)